### PR TITLE
Summary stats

### DIFF
--- a/docs/Enumerable.html
+++ b/docs/Enumerable.html
@@ -409,7 +409,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Apr 17 14:11:14 2020 by
+  Generated on Mon Apr 27 11:49:54 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.24 (ruby-2.6.3).
 </div>

--- a/docs/Numo.html
+++ b/docs/Numo.html
@@ -105,7 +105,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Apr 17 14:11:14 2020 by
+  Generated on Mon Apr 27 11:49:54 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.24 (ruby-2.6.3).
 </div>

--- a/docs/Numo/NArray.html
+++ b/docs/Numo/NArray.html
@@ -350,7 +350,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Apr 17 14:11:14 2020 by
+  Generated on Mon Apr 27 11:49:54 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.24 (ruby-2.6.3).
 </div>

--- a/docs/SpatialStats.html
+++ b/docs/SpatialStats.html
@@ -136,7 +136,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Apr 17 14:11:14 2020 by
+  Generated on Mon Apr 27 11:49:54 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.24 (ruby-2.6.3).
 </div>

--- a/docs/SpatialStats/Global.html
+++ b/docs/SpatialStats/Global.html
@@ -120,7 +120,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Apr 17 14:11:14 2020 by
+  Generated on Mon Apr 27 11:49:54 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.24 (ruby-2.6.3).
 </div>

--- a/docs/SpatialStats/Global/BivariateMoran.html
+++ b/docs/SpatialStats/Global/BivariateMoran.html
@@ -294,6 +294,30 @@
         <li class="public ">
   <span class="summary_signature">
     
+      <a href="#summary-instance_method" title="#summary (instance method)">#<strong>summary</strong>(permutations = 99, seed = nil)  &#x21d2; Hash </a>
+    
+
+    
+  </span>
+  
+  
+  
+  
+  
+  
+  
+
+  
+    <span class="summary_desc"><div class='inline'>
+<p>Summary of the statistic.</p>
+</div></span>
+  
+</li>
+
+      
+        <li class="public ">
+  <span class="summary_signature">
+    
       <a href="#variance-instance_method" title="#variance (instance method)">#<strong>variance</strong>  &#x21d2; Float </a>
     
 
@@ -488,13 +512,13 @@
       <pre class="lines">
 
 
-95
-96
-97
-98</pre>
+108
+109
+110
+111</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/spatial_stats/global/bivariate_moran.rb', line 95</span>
+      <pre class="code"><span class="info file"># File 'lib/spatial_stats/global/bivariate_moran.rb', line 108</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_x'>x</span>
   <span class='ivar'>@x</span> <span class='op'>||=</span> <span class='const'><span class='object_link'><a href="../../SpatialStats.html" title="SpatialStats (module)">SpatialStats</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Queries.html" title="SpatialStats::Queries (module)">Queries</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Queries/Variables.html" title="SpatialStats::Queries::Variables (module)">Variables</a></span></span><span class='period'>.</span><span class='id identifier rubyid_query_field'><span class='object_link'><a href="../Queries/Variables.html#query_field-class_method" title="SpatialStats::Queries::Variables.query_field (method)">query_field</a></span></span><span class='lparen'>(</span><span class='ivar'>@scope</span><span class='comma'>,</span> <span class='ivar'>@x_field</span><span class='rparen'>)</span>
@@ -546,13 +570,13 @@
       <pre class="lines">
 
 
-104
-105
-106
-107</pre>
+117
+118
+119
+120</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/spatial_stats/global/bivariate_moran.rb', line 104</span>
+      <pre class="code"><span class="info file"># File 'lib/spatial_stats/global/bivariate_moran.rb', line 117</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_y'>y</span>
   <span class='ivar'>@y</span> <span class='op'>||=</span> <span class='const'><span class='object_link'><a href="../../SpatialStats.html" title="SpatialStats (module)">SpatialStats</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Queries.html" title="SpatialStats::Queries (module)">Queries</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Queries/Variables.html" title="SpatialStats::Queries::Variables (module)">Variables</a></span></span><span class='period'>.</span><span class='id identifier rubyid_query_field'><span class='object_link'><a href="../Queries/Variables.html#query_field-class_method" title="SpatialStats::Queries::Variables.query_field (method)">query_field</a></span></span><span class='lparen'>(</span><span class='ivar'>@scope</span><span class='comma'>,</span> <span class='ivar'>@y_field</span><span class='rparen'>)</span>
@@ -805,6 +829,102 @@
 </div>
     
       <div class="method_details ">
+  <h3 class="signature " id="summary-instance_method">
+  
+    #<strong>summary</strong>(permutations = 99, seed = nil)  &#x21d2; <tt>Hash</tt> 
+  
+
+  
+
+  
+</h3><div class="docstring">
+  <div class="discussion">
+    
+<p>Summary of the statistic. Computes <code>stat</code> and <code>mc</code> and returns the values in a hash.</p>
+
+
+  </div>
+</div>
+<div class="tags">
+  <p class="tag_title">Parameters:</p>
+<ul class="param">
+  
+    <li>
+      
+        <span class='name'>permutations</span>
+      
+      
+        <span class='type'>(<tt>Integer</tt>)</span>
+      
+      
+        <em class="default">(defaults to: <tt>99</tt>)</em>
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>to run. Last digit should be 9 to produce round numbers.</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>seed</span>
+      
+      
+        <span class='type'>(<tt>Integer</tt>)</span>
+      
+      
+        <em class="default">(defaults to: <tt>nil</tt>)</em>
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>used in random number generator for shuffles.</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt>Hash</tt>)</span>
+      
+      
+      
+    </li>
+  
+</ul>
+
+</div><table class="source_code">
+  <tr>
+    <td>
+      <pre class="lines">
+
+
+99
+100
+101
+102</pre>
+    </td>
+    <td>
+      <pre class="code"><span class="info file"># File 'lib/spatial_stats/global/bivariate_moran.rb', line 99</span>
+
+<span class='kw'>def</span> <span class='id identifier rubyid_summary'>summary</span><span class='lparen'>(</span><span class='id identifier rubyid_permutations'>permutations</span> <span class='op'>=</span> <span class='int'>99</span><span class='comma'>,</span> <span class='id identifier rubyid_seed'>seed</span> <span class='op'>=</span> <span class='kw'>nil</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_p_val'>p_val</span> <span class='op'>=</span> <span class='id identifier rubyid_mc'>mc</span><span class='lparen'>(</span><span class='id identifier rubyid_permutations'>permutations</span><span class='comma'>,</span> <span class='id identifier rubyid_seed'>seed</span><span class='rparen'>)</span>
+  <span class='lbrace'>{</span> <span class='label'>stat:</span> <span class='id identifier rubyid_stat'>stat</span><span class='comma'>,</span> <span class='label'>p:</span> <span class='id identifier rubyid_p_val'>p_val</span> <span class='rbrace'>}</span>
+<span class='kw'>end</span></pre>
+    </td>
+  </tr>
+</table>
+</div>
+    
+      <div class="method_details ">
   <h3 class="signature " id="variance-instance_method">
   
     #<strong>variance</strong>  &#x21d2; <tt>Float</tt> 
@@ -900,7 +1020,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Apr 17 14:11:15 2020 by
+  Generated on Mon Apr 27 11:49:55 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.24 (ruby-2.6.3).
 </div>

--- a/docs/SpatialStats/Global/Moran.html
+++ b/docs/SpatialStats/Global/Moran.html
@@ -269,6 +269,30 @@
         <li class="public ">
   <span class="summary_signature">
     
+      <a href="#summary-instance_method" title="#summary (instance method)">#<strong>summary</strong>(permutations = 99, seed = nil)  &#x21d2; Hash </a>
+    
+
+    
+  </span>
+  
+  
+  
+  
+  
+  
+  
+
+  
+    <span class="summary_desc"><div class='inline'>
+<p>Summary of the statistic.</p>
+</div></span>
+  
+</li>
+
+      
+        <li class="public ">
+  <span class="summary_signature">
+    
       <a href="#variance-instance_method" title="#variance (instance method)">#<strong>variance</strong>  &#x21d2; Float </a>
     
 
@@ -445,13 +469,13 @@
       <pre class="lines">
 
 
-98
-99
-100
-101</pre>
+111
+112
+113
+114</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/spatial_stats/global/moran.rb', line 98</span>
+      <pre class="code"><span class="info file"># File 'lib/spatial_stats/global/moran.rb', line 111</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_x'>x</span>
   <span class='ivar'>@x</span> <span class='op'>||=</span> <span class='const'><span class='object_link'><a href="../../SpatialStats.html" title="SpatialStats (module)">SpatialStats</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Queries.html" title="SpatialStats::Queries (module)">Queries</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Queries/Variables.html" title="SpatialStats::Queries::Variables (module)">Variables</a></span></span><span class='period'>.</span><span class='id identifier rubyid_query_field'><span class='object_link'><a href="../Queries/Variables.html#query_field-class_method" title="SpatialStats::Queries::Variables.query_field (method)">query_field</a></span></span><span class='lparen'>(</span><span class='ivar'>@scope</span><span class='comma'>,</span> <span class='ivar'>@field</span><span class='rparen'>)</span>
@@ -714,6 +738,102 @@
 </div>
     
       <div class="method_details ">
+  <h3 class="signature " id="summary-instance_method">
+  
+    #<strong>summary</strong>(permutations = 99, seed = nil)  &#x21d2; <tt>Hash</tt> 
+  
+
+  
+
+  
+</h3><div class="docstring">
+  <div class="discussion">
+    
+<p>Summary of the statistic. Computes <code>stat</code> and <code>mc</code> and returns the values in a hash.</p>
+
+
+  </div>
+</div>
+<div class="tags">
+  <p class="tag_title">Parameters:</p>
+<ul class="param">
+  
+    <li>
+      
+        <span class='name'>permutations</span>
+      
+      
+        <span class='type'>(<tt>Integer</tt>)</span>
+      
+      
+        <em class="default">(defaults to: <tt>99</tt>)</em>
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>to run. Last digit should be 9 to produce round numbers.</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>seed</span>
+      
+      
+        <span class='type'>(<tt>Integer</tt>)</span>
+      
+      
+        <em class="default">(defaults to: <tt>nil</tt>)</em>
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>used in random number generator for shuffles.</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt>Hash</tt>)</span>
+      
+      
+      
+    </li>
+  
+</ul>
+
+</div><table class="source_code">
+  <tr>
+    <td>
+      <pre class="lines">
+
+
+102
+103
+104
+105</pre>
+    </td>
+    <td>
+      <pre class="code"><span class="info file"># File 'lib/spatial_stats/global/moran.rb', line 102</span>
+
+<span class='kw'>def</span> <span class='id identifier rubyid_summary'>summary</span><span class='lparen'>(</span><span class='id identifier rubyid_permutations'>permutations</span> <span class='op'>=</span> <span class='int'>99</span><span class='comma'>,</span> <span class='id identifier rubyid_seed'>seed</span> <span class='op'>=</span> <span class='kw'>nil</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_p_val'>p_val</span> <span class='op'>=</span> <span class='id identifier rubyid_mc'>mc</span><span class='lparen'>(</span><span class='id identifier rubyid_permutations'>permutations</span><span class='comma'>,</span> <span class='id identifier rubyid_seed'>seed</span><span class='rparen'>)</span>
+  <span class='lbrace'>{</span> <span class='label'>stat:</span> <span class='id identifier rubyid_stat'>stat</span><span class='comma'>,</span> <span class='label'>p:</span> <span class='id identifier rubyid_p_val'>p_val</span> <span class='rbrace'>}</span>
+<span class='kw'>end</span></pre>
+    </td>
+  </tr>
+</table>
+</div>
+    
+      <div class="method_details ">
   <h3 class="signature " id="variance-instance_method">
   
     #<strong>variance</strong>  &#x21d2; <tt>Float</tt> 
@@ -809,7 +929,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Apr 17 14:11:14 2020 by
+  Generated on Mon Apr 27 11:49:54 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.24 (ruby-2.6.3).
 </div>

--- a/docs/SpatialStats/Global/Stat.html
+++ b/docs/SpatialStats/Global/Stat.html
@@ -942,7 +942,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Apr 17 14:11:14 2020 by
+  Generated on Mon Apr 27 11:49:54 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.24 (ruby-2.6.3).
 </div>

--- a/docs/SpatialStats/Local.html
+++ b/docs/SpatialStats/Local.html
@@ -120,7 +120,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Apr 17 14:11:14 2020 by
+  Generated on Mon Apr 27 11:49:54 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.24 (ruby-2.6.3).
 </div>

--- a/docs/SpatialStats/Local/BivariateMoran.html
+++ b/docs/SpatialStats/Local/BivariateMoran.html
@@ -176,6 +176,31 @@
       <li class="public ">
   <span class="summary_signature">
     
+      <a href="#x-instance_method" title="#x (instance method)">#<strong>x</strong>  &#x21d2; Object </a>
+    
+
+    
+  </span>
+  
+  
+  
+    
+    
+  
+  
+  
+  
+  
+
+  
+    <span class="summary_desc"><div class='inline'></div></span>
+  
+</li>
+
+    
+      <li class="public ">
+  <span class="summary_signature">
+    
       <a href="#x_field-instance_method" title="#x_field (instance method)">#<strong>x_field</strong>  &#x21d2; Object </a>
     
 
@@ -196,6 +221,31 @@
     <span class="summary_desc"><div class='inline'>
 <p>Returns the value of attribute x_field.</p>
 </div></span>
+  
+</li>
+
+    
+      <li class="public ">
+  <span class="summary_signature">
+    
+      <a href="#y-instance_method" title="#y (instance method)">#<strong>y</strong>  &#x21d2; Object </a>
+    
+
+    
+  </span>
+  
+  
+  
+    
+    
+  
+  
+  
+  
+  
+
+  
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -298,6 +348,32 @@
         <li class="public ">
   <span class="summary_signature">
     
+      <a href="#quads-instance_method" title="#quads (instance method)">#<strong>quads</strong>  &#x21d2; Array </a>
+    
+
+    
+      (also: #groups)
+    
+  </span>
+  
+  
+  
+  
+  
+  
+  
+
+  
+    <span class="summary_desc"><div class='inline'>
+<p>Determines what quadrant an observation is in.</p>
+</div></span>
+  
+</li>
+
+      
+        <li class="public ">
+  <span class="summary_signature">
+    
       <a href="#stat-instance_method" title="#stat (instance method)">#<strong>stat</strong>  &#x21d2; Array </a>
     
 
@@ -348,7 +424,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#x-instance_method" title="#x (instance method)">#<strong>x</strong>  &#x21d2; Object </a>
+      <a href="#summary-instance_method" title="#summary (instance method)">#<strong>summary</strong>(permutations = 99, seed = nil)  &#x21d2; Array </a>
     
 
     
@@ -362,29 +438,9 @@
   
 
   
-    <span class="summary_desc"><div class='inline'></div></span>
-  
-</li>
-
-      
-        <li class="public ">
-  <span class="summary_signature">
-    
-      <a href="#y-instance_method" title="#y (instance method)">#<strong>y</strong>  &#x21d2; Object </a>
-    
-
-    
-  </span>
-  
-  
-  
-  
-  
-  
-  
-
-  
-    <span class="summary_desc"><div class='inline'></div></span>
+    <span class="summary_desc"><div class='inline'>
+<p>Summary of the statistic.</p>
+</div></span>
   
 </li>
 
@@ -402,7 +458,7 @@
   
   
   <h3 class="inherited">Methods inherited from <span class='object_link'><a href="Stat.html" title="SpatialStats::Local::Stat (class)">Stat</a></span></h3>
-  <p class="inherited"><span class='object_link'><a href="Stat.html#crand-instance_method" title="SpatialStats::Local::Stat#crand (method)">#crand</a></span>, <span class='object_link'><a href="Stat.html#expectation-instance_method" title="SpatialStats::Local::Stat#expectation (method)">#expectation</a></span>, <span class='object_link'><a href="Stat.html#mc_bv-instance_method" title="SpatialStats::Local::Stat#mc_bv (method)">#mc_bv</a></span>, <span class='object_link'><a href="Stat.html#quads-instance_method" title="SpatialStats::Local::Stat#quads (method)">#quads</a></span>, <span class='object_link'><a href="Stat.html#variance-instance_method" title="SpatialStats::Local::Stat#variance (method)">#variance</a></span>, <span class='object_link'><a href="Stat.html#z_score-instance_method" title="SpatialStats::Local::Stat#z_score (method)">#z_score</a></span></p>
+  <p class="inherited"><span class='object_link'><a href="Stat.html#crand-instance_method" title="SpatialStats::Local::Stat#crand (method)">#crand</a></span>, <span class='object_link'><a href="Stat.html#expectation-instance_method" title="SpatialStats::Local::Stat#expectation (method)">#expectation</a></span>, <span class='object_link'><a href="Stat.html#mc_bv-instance_method" title="SpatialStats::Local::Stat#mc_bv (method)">#mc_bv</a></span>, <span class='object_link'><a href="Stat.html#variance-instance_method" title="SpatialStats::Local::Stat#variance (method)">#variance</a></span>, <span class='object_link'><a href="Stat.html#z_score-instance_method" title="SpatialStats::Local::Stat#z_score (method)">#z_score</a></span></p>
 <div id="constructor_details" class="method_details_list">
   <h2>Constructor Details</h2>
   
@@ -608,6 +664,40 @@
 </div>
     
       
+      <span id="x=-instance_method"></span>
+      <div class="method_details ">
+  <h3 class="signature " id="x-instance_method">
+  
+    #<strong>x</strong>  &#x21d2; <tt>Object</tt> 
+  
+
+  
+
+  
+</h3><table class="source_code">
+  <tr>
+    <td>
+      <pre class="lines">
+
+
+121
+122
+123
+124</pre>
+    </td>
+    <td>
+      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/bivariate_moran.rb', line 121</span>
+
+<span class='kw'>def</span> <span class='id identifier rubyid_x'>x</span>
+  <span class='ivar'>@x</span> <span class='op'>||=</span> <span class='const'><span class='object_link'><a href="../../SpatialStats.html" title="SpatialStats (module)">SpatialStats</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Queries.html" title="SpatialStats::Queries (module)">Queries</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Queries/Variables.html" title="SpatialStats::Queries::Variables (module)">Variables</a></span></span><span class='period'>.</span><span class='id identifier rubyid_query_field'><span class='object_link'><a href="../Queries/Variables.html#query_field-class_method" title="SpatialStats::Queries::Variables.query_field (method)">query_field</a></span></span><span class='lparen'>(</span><span class='ivar'>@scope</span><span class='comma'>,</span> <span class='ivar'>@x_field</span><span class='rparen'>)</span>
+                                         <span class='period'>.</span><span class='id identifier rubyid_standardize'>standardize</span>
+<span class='kw'>end</span></pre>
+    </td>
+  </tr>
+</table>
+</div>
+    
+      
       <span id="x_field=-instance_method"></span>
       <div class="method_details ">
   <h3 class="signature " id="x_field-instance_method">
@@ -644,6 +734,40 @@
 
 <span class='kw'>def</span> <span class='id identifier rubyid_x_field'>x_field</span>
   <span class='ivar'>@x_field</span>
+<span class='kw'>end</span></pre>
+    </td>
+  </tr>
+</table>
+</div>
+    
+      
+      <span id="y=-instance_method"></span>
+      <div class="method_details ">
+  <h3 class="signature " id="y-instance_method">
+  
+    #<strong>y</strong>  &#x21d2; <tt>Object</tt> 
+  
+
+  
+
+  
+</h3><table class="source_code">
+  <tr>
+    <td>
+      <pre class="lines">
+
+
+126
+127
+128
+129</pre>
+    </td>
+    <td>
+      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/bivariate_moran.rb', line 126</span>
+
+<span class='kw'>def</span> <span class='id identifier rubyid_y'>y</span>
+  <span class='ivar'>@y</span> <span class='op'>||=</span> <span class='const'><span class='object_link'><a href="../../SpatialStats.html" title="SpatialStats (module)">SpatialStats</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Queries.html" title="SpatialStats::Queries (module)">Queries</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Queries/Variables.html" title="SpatialStats::Queries::Variables (module)">Variables</a></span></span><span class='period'>.</span><span class='id identifier rubyid_query_field'><span class='object_link'><a href="../Queries/Variables.html#query_field-class_method" title="SpatialStats::Queries::Variables.query_field (method)">query_field</a></span></span><span class='lparen'>(</span><span class='ivar'>@scope</span><span class='comma'>,</span> <span class='ivar'>@y_field</span><span class='rparen'>)</span>
+                                         <span class='period'>.</span><span class='id identifier rubyid_standardize'>standardize</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -791,15 +915,131 @@
       <pre class="lines">
 
 
-61
 62
-63</pre>
+63
+64</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/bivariate_moran.rb', line 61</span>
+      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/bivariate_moran.rb', line 62</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_mc'>mc</span><span class='lparen'>(</span><span class='id identifier rubyid_permutations'>permutations</span> <span class='op'>=</span> <span class='int'>99</span><span class='comma'>,</span> <span class='id identifier rubyid_seed'>seed</span> <span class='op'>=</span> <span class='kw'>nil</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_mc_bv'>mc_bv</span><span class='lparen'>(</span><span class='id identifier rubyid_permutations'>permutations</span><span class='comma'>,</span> <span class='id identifier rubyid_seed'>seed</span><span class='rparen'>)</span>
+<span class='kw'>end</span></pre>
+    </td>
+  </tr>
+</table>
+</div>
+    
+      <div class="method_details ">
+  <h3 class="signature " id="quads-instance_method">
+  
+    #<strong>quads</strong>  &#x21d2; <tt>Array</tt> 
+  
+
+  
+    <span class="aliases">Also known as:
+    <span class="names"><span id='groups-instance_method'>groups</span></span>
+    </span>
+  
+
+  
+</h3><div class="docstring">
+  <div class="discussion">
+    
+<p>Determines what quadrant an observation is in. Based on its value compared to its neighbors. This does not work for all stats, since it requires that values be negative.</p>
+
+<p>In a standardized array of z, high values are values greater than 0 and it&#39;s neighbors are determined by the spatial lag and if that is positive then it&#39;s neighbors would be high, low otherwise.</p>
+
+<p>Quadrants are:</p>
+<dl class="rdoc-list label-list"><dt>HH
+<dd>
+<p>a high value surrounded by other high values</p>
+</dd><dt>LH
+<dd>
+<p>a low value surrounded by high values</p>
+</dd><dt>LL
+<dd>
+<p>a low value surrounded by low values</p>
+</dd><dt>HL
+<dd>
+<p>a high value surrounded by low values</p>
+</dd></dl>
+
+
+  </div>
+</div>
+<div class="tags">
+  
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt>Array</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>of labels</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+</div><table class="source_code">
+  <tr>
+    <td>
+      <pre class="lines">
+
+
+82
+83
+84
+85
+86
+87
+88
+89
+90
+91
+92
+93
+94
+95
+96
+97
+98
+99
+100
+101
+102</pre>
+    </td>
+    <td>
+      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/bivariate_moran.rb', line 82</span>
+
+<span class='kw'>def</span> <span class='id identifier rubyid_quads'>quads</span>
+  <span class='comment'># https://github.com/pysal/esda/blob/master/esda/moran.py#L925
+</span>  <span class='id identifier rubyid_z_lag'>z_lag</span> <span class='op'>=</span> <span class='const'><span class='object_link'><a href="../../SpatialStats.html" title="SpatialStats (module)">SpatialStats</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Utils.html" title="SpatialStats::Utils (module)">Utils</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Utils/Lag.html" title="SpatialStats::Utils::Lag (module)">Lag</a></span></span><span class='period'>.</span><span class='id identifier rubyid_neighbor_average'><span class='object_link'><a href="../Utils/Lag.html#neighbor_average-class_method" title="SpatialStats::Utils::Lag.neighbor_average (method)">neighbor_average</a></span></span><span class='lparen'>(</span><span class='id identifier rubyid_weights'>weights</span><span class='comma'>,</span> <span class='id identifier rubyid_y'>y</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_zp'>zp</span> <span class='op'>=</span> <span class='id identifier rubyid_x'>x</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span><span class='lparen'>(</span><span class='op'>&amp;</span><span class='symbol'>:positive?</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_lp'>lp</span> <span class='op'>=</span> <span class='id identifier rubyid_z_lag'>z_lag</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span><span class='lparen'>(</span><span class='op'>&amp;</span><span class='symbol'>:positive?</span><span class='rparen'>)</span>
+
+  <span class='comment'># hh = zp &amp; lp
+</span>  <span class='comment'># lh = zp ^ true &amp; lp
+</span>  <span class='comment'># ll = zp ^ true &amp; lp ^ true
+</span>  <span class='comment'># hl = zp next to lp ^ true
+</span>  <span class='id identifier rubyid_hh'>hh</span> <span class='op'>=</span> <span class='id identifier rubyid_zp'>zp</span><span class='period'>.</span><span class='id identifier rubyid_each_with_index'>each_with_index</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span> <span class='lbrace'>{</span> <span class='op'>|</span><span class='id identifier rubyid_v'>v</span><span class='comma'>,</span> <span class='id identifier rubyid_idx'>idx</span><span class='op'>|</span> <span class='id identifier rubyid_v'>v</span> <span class='op'>&amp;</span> <span class='id identifier rubyid_lp'>lp</span><span class='lbracket'>[</span><span class='id identifier rubyid_idx'>idx</span><span class='rbracket'>]</span> <span class='rbrace'>}</span>
+  <span class='id identifier rubyid_lh'>lh</span> <span class='op'>=</span> <span class='id identifier rubyid_zp'>zp</span><span class='period'>.</span><span class='id identifier rubyid_each_with_index'>each_with_index</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span> <span class='lbrace'>{</span> <span class='op'>|</span><span class='id identifier rubyid_v'>v</span><span class='comma'>,</span> <span class='id identifier rubyid_idx'>idx</span><span class='op'>|</span> <span class='lparen'>(</span><span class='id identifier rubyid_v'>v</span> <span class='op'>^</span> <span class='kw'>true</span><span class='rparen'>)</span> <span class='op'>&amp;</span> <span class='id identifier rubyid_lp'>lp</span><span class='lbracket'>[</span><span class='id identifier rubyid_idx'>idx</span><span class='rbracket'>]</span> <span class='rbrace'>}</span>
+  <span class='id identifier rubyid_ll'>ll</span> <span class='op'>=</span> <span class='id identifier rubyid_zp'>zp</span><span class='period'>.</span><span class='id identifier rubyid_each_with_index'>each_with_index</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span> <span class='lbrace'>{</span> <span class='op'>|</span><span class='id identifier rubyid_v'>v</span><span class='comma'>,</span> <span class='id identifier rubyid_idx'>idx</span><span class='op'>|</span> <span class='lparen'>(</span><span class='id identifier rubyid_v'>v</span> <span class='op'>^</span> <span class='kw'>true</span><span class='rparen'>)</span> <span class='op'>&amp;</span> <span class='lparen'>(</span><span class='id identifier rubyid_lp'>lp</span><span class='lbracket'>[</span><span class='id identifier rubyid_idx'>idx</span><span class='rbracket'>]</span> <span class='op'>^</span> <span class='kw'>true</span><span class='rparen'>)</span> <span class='rbrace'>}</span>
+  <span class='id identifier rubyid_hl'>hl</span> <span class='op'>=</span> <span class='id identifier rubyid_zp'>zp</span><span class='period'>.</span><span class='id identifier rubyid_each_with_index'>each_with_index</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span> <span class='lbrace'>{</span> <span class='op'>|</span><span class='id identifier rubyid_v'>v</span><span class='comma'>,</span> <span class='id identifier rubyid_idx'>idx</span><span class='op'>|</span> <span class='id identifier rubyid_v'>v</span> <span class='op'>&amp;</span> <span class='lparen'>(</span><span class='id identifier rubyid_lp'>lp</span><span class='lbracket'>[</span><span class='id identifier rubyid_idx'>idx</span><span class='rbracket'>]</span> <span class='op'>^</span> <span class='kw'>true</span><span class='rparen'>)</span> <span class='rbrace'>}</span>
+
+  <span class='comment'># now zip lists and map them to proper terms
+</span>  <span class='id identifier rubyid_quad_terms'>quad_terms</span> <span class='op'>=</span> <span class='qwords_beg'>%w[</span><span class='tstring_content'>HH</span><span class='words_sep'> </span><span class='tstring_content'>LH</span><span class='words_sep'> </span><span class='tstring_content'>LL</span><span class='words_sep'> </span><span class='tstring_content'>HL</span><span class='tstring_end'>]</span></span>
+  <span class='id identifier rubyid_hh'>hh</span><span class='period'>.</span><span class='id identifier rubyid_zip'>zip</span><span class='lparen'>(</span><span class='id identifier rubyid_lh'>lh</span><span class='comma'>,</span> <span class='id identifier rubyid_ll'>ll</span><span class='comma'>,</span> <span class='id identifier rubyid_hl'>hl</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid_feature'>feature</span><span class='op'>|</span>
+    <span class='id identifier rubyid_quad_terms'>quad_terms</span><span class='lbracket'>[</span><span class='id identifier rubyid_feature'>feature</span><span class='period'>.</span><span class='id identifier rubyid_index'>index</span><span class='lparen'>(</span><span class='kw'>true</span><span class='rparen'>)</span><span class='rbracket'>]</span>
+  <span class='kw'>end</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -854,14 +1094,14 @@
       <pre class="lines">
 
 
-31
 32
 33
 34
-35</pre>
+35
+36</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/bivariate_moran.rb', line 31</span>
+      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/bivariate_moran.rb', line 32</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_stat'>stat</span>
   <span class='id identifier rubyid_x'>x</span><span class='period'>.</span><span class='id identifier rubyid_each_with_index'>each_with_index</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid__xi'>_xi</span><span class='comma'>,</span> <span class='id identifier rubyid_idx'>idx</span><span class='op'>|</span>
@@ -937,12 +1177,12 @@
       <pre class="lines">
 
 
-45
 46
-47</pre>
+47
+48</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/bivariate_moran.rb', line 45</span>
+      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/bivariate_moran.rb', line 46</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_stat_i'>stat_i</span><span class='lparen'>(</span><span class='id identifier rubyid_idx'>idx</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_x'>x</span><span class='lbracket'>[</span><span class='id identifier rubyid_idx'>idx</span><span class='rbracket'>]</span> <span class='op'>*</span> <span class='id identifier rubyid_y_lag'>y_lag</span><span class='lbracket'>[</span><span class='id identifier rubyid_idx'>idx</span><span class='rbracket'>]</span>
@@ -953,63 +1193,101 @@
 </div>
     
       <div class="method_details ">
-  <h3 class="signature " id="x-instance_method">
+  <h3 class="signature " id="summary-instance_method">
   
-    #<strong>x</strong>  &#x21d2; <tt>Object</tt> 
-  
-
+    #<strong>summary</strong>(permutations = 99, seed = nil)  &#x21d2; <tt>Array</tt> 
   
 
   
-</h3><table class="source_code">
-  <tr>
-    <td>
-      <pre class="lines">
 
-
-65
-66
-67
-68</pre>
-    </td>
-    <td>
-      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/bivariate_moran.rb', line 65</span>
-
-<span class='kw'>def</span> <span class='id identifier rubyid_x'>x</span>
-  <span class='ivar'>@x</span> <span class='op'>||=</span> <span class='const'><span class='object_link'><a href="../../SpatialStats.html" title="SpatialStats (module)">SpatialStats</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Queries.html" title="SpatialStats::Queries (module)">Queries</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Queries/Variables.html" title="SpatialStats::Queries::Variables (module)">Variables</a></span></span><span class='period'>.</span><span class='id identifier rubyid_query_field'><span class='object_link'><a href="../Queries/Variables.html#query_field-class_method" title="SpatialStats::Queries::Variables.query_field (method)">query_field</a></span></span><span class='lparen'>(</span><span class='ivar'>@scope</span><span class='comma'>,</span> <span class='ivar'>@x_field</span><span class='rparen'>)</span>
-                                         <span class='period'>.</span><span class='id identifier rubyid_standardize'>standardize</span>
-<span class='kw'>end</span></pre>
-    </td>
-  </tr>
-</table>
-</div>
+  
+</h3><div class="docstring">
+  <div class="discussion">
     
-      <div class="method_details ">
-  <h3 class="signature " id="y-instance_method">
-  
-    #<strong>y</strong>  &#x21d2; <tt>Object</tt> 
-  
+<p>Summary of the statistic. Computes <code>stat</code>, <code>mc</code>, and <code>groups</code> then returns the values in a hash array.</p>
 
-  
 
+  </div>
+</div>
+<div class="tags">
+  <p class="tag_title">Parameters:</p>
+<ul class="param">
   
-</h3><table class="source_code">
+    <li>
+      
+        <span class='name'>permutations</span>
+      
+      
+        <span class='type'>(<tt>Integer</tt>)</span>
+      
+      
+        <em class="default">(defaults to: <tt>99</tt>)</em>
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>to run. Last digit should be 9 to produce round numbers.</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>seed</span>
+      
+      
+        <span class='type'>(<tt>Integer</tt>)</span>
+      
+      
+        <em class="default">(defaults to: <tt>nil</tt>)</em>
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>used in random number generator for shuffles.</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt>Array</tt>)</span>
+      
+      
+      
+    </li>
+  
+</ul>
+
+</div><table class="source_code">
   <tr>
     <td>
       <pre class="lines">
 
 
-70
-71
-72
-73</pre>
+113
+114
+115
+116
+117
+118
+119</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/bivariate_moran.rb', line 70</span>
+      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/bivariate_moran.rb', line 113</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_y'>y</span>
-  <span class='ivar'>@y</span> <span class='op'>||=</span> <span class='const'><span class='object_link'><a href="../../SpatialStats.html" title="SpatialStats (module)">SpatialStats</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Queries.html" title="SpatialStats::Queries (module)">Queries</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Queries/Variables.html" title="SpatialStats::Queries::Variables (module)">Variables</a></span></span><span class='period'>.</span><span class='id identifier rubyid_query_field'><span class='object_link'><a href="../Queries/Variables.html#query_field-class_method" title="SpatialStats::Queries::Variables.query_field (method)">query_field</a></span></span><span class='lparen'>(</span><span class='ivar'>@scope</span><span class='comma'>,</span> <span class='ivar'>@y_field</span><span class='rparen'>)</span>
-                                         <span class='period'>.</span><span class='id identifier rubyid_standardize'>standardize</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_summary'>summary</span><span class='lparen'>(</span><span class='id identifier rubyid_permutations'>permutations</span> <span class='op'>=</span> <span class='int'>99</span><span class='comma'>,</span> <span class='id identifier rubyid_seed'>seed</span> <span class='op'>=</span> <span class='kw'>nil</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_p_vals'>p_vals</span> <span class='op'>=</span> <span class='id identifier rubyid_mc'>mc</span><span class='lparen'>(</span><span class='id identifier rubyid_permutations'>permutations</span><span class='comma'>,</span> <span class='id identifier rubyid_seed'>seed</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_data'>data</span> <span class='op'>=</span> <span class='id identifier rubyid_weights'>weights</span><span class='period'>.</span><span class='id identifier rubyid_keys'>keys</span><span class='period'>.</span><span class='id identifier rubyid_zip'>zip</span><span class='lparen'>(</span><span class='id identifier rubyid_stat'>stat</span><span class='comma'>,</span> <span class='id identifier rubyid_p_vals'>p_vals</span><span class='comma'>,</span> <span class='id identifier rubyid_groups'>groups</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_data'>data</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid_row'>row</span><span class='op'>|</span>
+    <span class='lbrace'>{</span> <span class='label'>key:</span> <span class='id identifier rubyid_row'>row</span><span class='lbracket'>[</span><span class='int'>0</span><span class='rbracket'>]</span><span class='comma'>,</span> <span class='label'>stat:</span> <span class='id identifier rubyid_row'>row</span><span class='lbracket'>[</span><span class='int'>1</span><span class='rbracket'>]</span><span class='comma'>,</span> <span class='label'>p:</span> <span class='id identifier rubyid_row'>row</span><span class='lbracket'>[</span><span class='int'>2</span><span class='rbracket'>]</span><span class='comma'>,</span> <span class='label'>group:</span> <span class='id identifier rubyid_row'>row</span><span class='lbracket'>[</span><span class='int'>3</span><span class='rbracket'>]</span> <span class='rbrace'>}</span>
+  <span class='kw'>end</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -1021,7 +1299,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Apr 17 14:11:14 2020 by
+  Generated on Mon Apr 27 11:49:55 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.24 (ruby-2.6.3).
 </div>

--- a/docs/SpatialStats/Local/Geary.html
+++ b/docs/SpatialStats/Local/Geary.html
@@ -116,9 +116,43 @@
 
 
 
+  <h2>Instance Attribute Summary <small><a href="#" class="summary_toggle">collapse</a></small></h2>
+  <ul class="summary">
+    
+      <li class="public ">
+  <span class="summary_signature">
+    
+      <a href="#x-instance_method" title="#x (instance method)">#<strong>x</strong>  &#x21d2; Array </a>
+    
+
+    
+      (also: #z)
+    
+  </span>
+  
+  
+  
+    
+    
+  
+  
+  
+  
+  
+
+  
+    <span class="summary_desc"><div class='inline'>
+<p>Values of the <code>field</code> queried from the <code>scope</code>.</p>
+</div></span>
+  
+</li>
+
+    
+  </ul>
 
 
-  <h2>Instance Attribute Summary</h2>
+
+  
   
   <h3 class="inherited">Attributes inherited from <span class='object_link'><a href="Stat.html" title="SpatialStats::Local::Stat (class)">Stat</a></span></h3>
   <p class="inherited"><span class='object_link'><a href="Stat.html#field-instance_method" title="SpatialStats::Local::Stat#field (method)">#field</a></span>, <span class='object_link'><a href="Stat.html#scope-instance_method" title="SpatialStats::Local::Stat#scope (method)">#scope</a></span>, <span class='object_link'><a href="Stat.html#weights-instance_method" title="SpatialStats::Local::Stat#weights (method)">#weights</a></span></p>
@@ -131,6 +165,30 @@
     </h2>
 
     <ul class="summary">
+      
+        <li class="public ">
+  <span class="summary_signature">
+    
+      <a href="#groups-instance_method" title="#groups (instance method)">#<strong>groups</strong>  &#x21d2; Array </a>
+    
+
+    
+  </span>
+  
+  
+  
+  
+  
+  
+  
+
+  
+    <span class="summary_desc"><div class='inline'>
+<p>Computes the groups each observation belongs to.</p>
+</div></span>
+  
+</li>
+
       
         <li class="public ">
   <span class="summary_signature">
@@ -184,32 +242,6 @@
 </li>
 
       
-        <li class="public ">
-  <span class="summary_signature">
-    
-      <a href="#x-instance_method" title="#x (instance method)">#<strong>x</strong>  &#x21d2; Array </a>
-    
-
-    
-      (also: #z)
-    
-  </span>
-  
-  
-  
-  
-  
-  
-  
-
-  
-    <span class="summary_desc"><div class='inline'>
-<p>Values of the <code>field</code> queried from the <code>scope</code>.</p>
-</div></span>
-  
-</li>
-
-      
     </ul>
   
 
@@ -223,7 +255,7 @@
   
   
   <h3 class="inherited">Methods inherited from <span class='object_link'><a href="Stat.html" title="SpatialStats::Local::Stat (class)">Stat</a></span></h3>
-  <p class="inherited"><span class='object_link'><a href="Stat.html#crand-instance_method" title="SpatialStats::Local::Stat#crand (method)">#crand</a></span>, <span class='object_link'><a href="Stat.html#expectation-instance_method" title="SpatialStats::Local::Stat#expectation (method)">#expectation</a></span>, <span class='object_link'><a href="Stat.html#mc-instance_method" title="SpatialStats::Local::Stat#mc (method)">#mc</a></span>, <span class='object_link'><a href="Stat.html#mc_bv-instance_method" title="SpatialStats::Local::Stat#mc_bv (method)">#mc_bv</a></span>, <span class='object_link'><a href="Stat.html#quads-instance_method" title="SpatialStats::Local::Stat#quads (method)">#quads</a></span>, <span class='object_link'><a href="Stat.html#variance-instance_method" title="SpatialStats::Local::Stat#variance (method)">#variance</a></span>, <span class='object_link'><a href="Stat.html#z_score-instance_method" title="SpatialStats::Local::Stat#z_score (method)">#z_score</a></span></p>
+  <p class="inherited"><span class='object_link'><a href="Stat.html#crand-instance_method" title="SpatialStats::Local::Stat#crand (method)">#crand</a></span>, <span class='object_link'><a href="Stat.html#expectation-instance_method" title="SpatialStats::Local::Stat#expectation (method)">#expectation</a></span>, <span class='object_link'><a href="Stat.html#mc-instance_method" title="SpatialStats::Local::Stat#mc (method)">#mc</a></span>, <span class='object_link'><a href="Stat.html#mc_bv-instance_method" title="SpatialStats::Local::Stat#mc_bv (method)">#mc_bv</a></span>, <span class='object_link'><a href="Stat.html#quads-instance_method" title="SpatialStats::Local::Stat#quads (method)">#quads</a></span>, <span class='object_link'><a href="Stat.html#summary-instance_method" title="SpatialStats::Local::Stat#summary (method)">#summary</a></span>, <span class='object_link'><a href="Stat.html#variance-instance_method" title="SpatialStats::Local::Stat#variance (method)">#variance</a></span>, <span class='object_link'><a href="Stat.html#z_score-instance_method" title="SpatialStats::Local::Stat#z_score (method)">#z_score</a></span></p>
 <div id="constructor_details" class="method_details_list">
   <h2>Constructor Details</h2>
   
@@ -317,13 +349,161 @@
   
 </div>
 
+  <div id="instance_attr_details" class="attr_details">
+    <h2>Instance Attribute Details</h2>
+    
+      
+      <span id="x=-instance_method"></span>
+      <div class="method_details first">
+  <h3 class="signature first" id="x-instance_method">
+  
+    #<strong>x</strong>  &#x21d2; <tt>Array</tt> 
+  
+
+  
+    <span class="aliases">Also known as:
+    <span class="names"><span id='z-instance_method'>z</span></span>
+    </span>
+  
+
+  
+</h3><div class="docstring">
+  <div class="discussion">
+    
+<p>Values of the <code>field</code> queried from the <code>scope</code></p>
+
+
+  </div>
+</div>
+<div class="tags">
+  
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt>Array</tt>)</span>
+      
+      
+      
+    </li>
+  
+</ul>
+
+</div><table class="source_code">
+  <tr>
+    <td>
+      <pre class="lines">
+
+
+59
+60
+61
+62</pre>
+    </td>
+    <td>
+      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/geary.rb', line 59</span>
+
+<span class='kw'>def</span> <span class='id identifier rubyid_x'>x</span>
+  <span class='ivar'>@x</span> <span class='op'>||=</span> <span class='const'><span class='object_link'><a href="../../SpatialStats.html" title="SpatialStats (module)">SpatialStats</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Queries.html" title="SpatialStats::Queries (module)">Queries</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Queries/Variables.html" title="SpatialStats::Queries::Variables (module)">Variables</a></span></span><span class='period'>.</span><span class='id identifier rubyid_query_field'><span class='object_link'><a href="../Queries/Variables.html#query_field-class_method" title="SpatialStats::Queries::Variables.query_field (method)">query_field</a></span></span><span class='lparen'>(</span><span class='ivar'>@scope</span><span class='comma'>,</span> <span class='ivar'>@field</span><span class='rparen'>)</span>
+                                         <span class='period'>.</span><span class='id identifier rubyid_standardize'>standardize</span>
+<span class='kw'>end</span></pre>
+    </td>
+  </tr>
+</table>
+</div>
+    
+  </div>
+
 
   <div id="instance_method_details" class="method_details_list">
     <h2>Instance Method Details</h2>
 
     
       <div class="method_details first">
-  <h3 class="signature first" id="stat-instance_method">
+  <h3 class="signature first" id="groups-instance_method">
+  
+    #<strong>groups</strong>  &#x21d2; <tt>Array</tt> 
+  
+
+  
+
+  
+</h3><div class="docstring">
+  <div class="discussion">
+    
+<p>Computes the groups each observation belongs to. Potential groups for Geary&#39;s C are:</p>
+<dl class="rdoc-list label-list"><dt>HH
+<dd>
+<p>High-High</p>
+</dd><dt>LL
+<dd>
+<p>Low-Low</p>
+</dd><dt>N
+<dd>
+<p>Negative - Group traditionally for HL and LH, but since the difference is squared they are in the same group.</p>
+</dd></dl>
+
+
+  </div>
+</div>
+<div class="tags">
+  
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt>Array</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>groups for each observation</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+</div><table class="source_code">
+  <tr>
+    <td>
+      <pre class="lines">
+
+
+45
+46
+47
+48
+49
+50
+51
+52
+53</pre>
+    </td>
+    <td>
+      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/geary.rb', line 45</span>
+
+<span class='kw'>def</span> <span class='id identifier rubyid_groups'>groups</span>
+  <span class='id identifier rubyid_quads'>quads</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid_quad'>quad</span><span class='op'>|</span>
+    <span class='kw'>if</span> <span class='qwords_beg'>%w[</span><span class='tstring_content'>HL</span><span class='words_sep'> </span><span class='tstring_content'>LH</span><span class='tstring_end'>]</span></span><span class='period'>.</span><span class='id identifier rubyid_include?'>include?</span><span class='lparen'>(</span><span class='id identifier rubyid_quad'>quad</span><span class='rparen'>)</span>
+      <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>N</span><span class='tstring_end'>&#39;</span></span>
+    <span class='kw'>else</span>
+      <span class='id identifier rubyid_quad'>quad</span>
+    <span class='kw'>end</span>
+  <span class='kw'>end</span>
+<span class='kw'>end</span></pre>
+    </td>
+  </tr>
+</table>
+</div>
+    
+      <div class="method_details ">
+  <h3 class="signature " id="stat-instance_method">
   
     #<strong>stat</strong>  &#x21d2; <tt>Array</tt> 
   
@@ -370,14 +550,14 @@
       <pre class="lines">
 
 
-28
 29
 30
 31
-32</pre>
+32
+33</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/geary.rb', line 28</span>
+      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/geary.rb', line 29</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_stat'>stat</span>
   <span class='id identifier rubyid_z'>z</span><span class='period'>.</span><span class='id identifier rubyid_each_with_index'>each_with_index</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid__zi'>_zi</span><span class='comma'>,</span> <span class='id identifier rubyid_idx'>idx</span><span class='op'>|</span>
@@ -389,72 +569,12 @@
 </table>
 </div>
     
-      <div class="method_details ">
-  <h3 class="signature " id="x-instance_method">
-  
-    #<strong>x</strong>  &#x21d2; <tt>Array</tt> 
-  
-
-  
-    <span class="aliases">Also known as:
-    <span class="names"><span id='z-instance_method'>z</span></span>
-    </span>
-  
-
-  
-</h3><div class="docstring">
-  <div class="discussion">
-    
-<p>Values of the <code>field</code> queried from the <code>scope</code></p>
-
-
-  </div>
-</div>
-<div class="tags">
-  
-<p class="tag_title">Returns:</p>
-<ul class="return">
-  
-    <li>
-      
-      
-        <span class='type'>(<tt>Array</tt>)</span>
-      
-      
-      
-    </li>
-  
-</ul>
-
-</div><table class="source_code">
-  <tr>
-    <td>
-      <pre class="lines">
-
-
-39
-40
-41
-42</pre>
-    </td>
-    <td>
-      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/geary.rb', line 39</span>
-
-<span class='kw'>def</span> <span class='id identifier rubyid_x'>x</span>
-  <span class='ivar'>@x</span> <span class='op'>||=</span> <span class='const'><span class='object_link'><a href="../../SpatialStats.html" title="SpatialStats (module)">SpatialStats</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Queries.html" title="SpatialStats::Queries (module)">Queries</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Queries/Variables.html" title="SpatialStats::Queries::Variables (module)">Variables</a></span></span><span class='period'>.</span><span class='id identifier rubyid_query_field'><span class='object_link'><a href="../Queries/Variables.html#query_field-class_method" title="SpatialStats::Queries::Variables.query_field (method)">query_field</a></span></span><span class='lparen'>(</span><span class='ivar'>@scope</span><span class='comma'>,</span> <span class='ivar'>@field</span><span class='rparen'>)</span>
-                                         <span class='period'>.</span><span class='id identifier rubyid_standardize'>standardize</span>
-<span class='kw'>end</span></pre>
-    </td>
-  </tr>
-</table>
-</div>
-    
   </div>
 
 </div>
 
       <div id="footer">
-  Generated on Fri Apr 17 14:11:14 2020 by
+  Generated on Mon Apr 27 11:49:54 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.24 (ruby-2.6.3).
 </div>

--- a/docs/SpatialStats/Local/GetisOrd.html
+++ b/docs/SpatialStats/Local/GetisOrd.html
@@ -146,6 +146,35 @@
 </li>
 
     
+      <li class="public ">
+  <span class="summary_signature">
+    
+      <a href="#x-instance_method" title="#x (instance method)">#<strong>x</strong>  &#x21d2; Array </a>
+    
+
+    
+      (also: #z)
+    
+  </span>
+  
+  
+  
+    
+    
+  
+  
+  
+  
+  
+
+  
+    <span class="summary_desc"><div class='inline'>
+<p>Values of the <code>field</code> queried from the <code>scope</code>.</p>
+</div></span>
+  
+</li>
+
+    
   </ul>
 
 
@@ -163,6 +192,30 @@
     </h2>
 
     <ul class="summary">
+      
+        <li class="public ">
+  <span class="summary_signature">
+    
+      <a href="#groups-instance_method" title="#groups (instance method)">#<strong>groups</strong>  &#x21d2; Array </a>
+    
+
+    
+  </span>
+  
+  
+  
+  
+  
+  
+  
+
+  
+    <span class="summary_desc"><div class='inline'>
+<p>Computes the groups each observation belongs to.</p>
+</div></span>
+  
+</li>
+
       
         <li class="public ">
   <span class="summary_signature">
@@ -240,32 +293,6 @@
 </li>
 
       
-        <li class="public ">
-  <span class="summary_signature">
-    
-      <a href="#x-instance_method" title="#x (instance method)">#<strong>x</strong>  &#x21d2; Array </a>
-    
-
-    
-      (also: #z)
-    
-  </span>
-  
-  
-  
-  
-  
-  
-  
-
-  
-    <span class="summary_desc"><div class='inline'>
-<p>Values of the <code>field</code> queried from the <code>scope</code>.</p>
-</div></span>
-  
-</li>
-
-      
     </ul>
   
 
@@ -279,7 +306,7 @@
   
   
   <h3 class="inherited">Methods inherited from <span class='object_link'><a href="Stat.html" title="SpatialStats::Local::Stat (class)">Stat</a></span></h3>
-  <p class="inherited"><span class='object_link'><a href="Stat.html#crand-instance_method" title="SpatialStats::Local::Stat#crand (method)">#crand</a></span>, <span class='object_link'><a href="Stat.html#expectation-instance_method" title="SpatialStats::Local::Stat#expectation (method)">#expectation</a></span>, <span class='object_link'><a href="Stat.html#mc-instance_method" title="SpatialStats::Local::Stat#mc (method)">#mc</a></span>, <span class='object_link'><a href="Stat.html#mc_bv-instance_method" title="SpatialStats::Local::Stat#mc_bv (method)">#mc_bv</a></span>, <span class='object_link'><a href="Stat.html#quads-instance_method" title="SpatialStats::Local::Stat#quads (method)">#quads</a></span>, <span class='object_link'><a href="Stat.html#variance-instance_method" title="SpatialStats::Local::Stat#variance (method)">#variance</a></span>, <span class='object_link'><a href="Stat.html#z_score-instance_method" title="SpatialStats::Local::Stat#z_score (method)">#z_score</a></span></p>
+  <p class="inherited"><span class='object_link'><a href="Stat.html#crand-instance_method" title="SpatialStats::Local::Stat#crand (method)">#crand</a></span>, <span class='object_link'><a href="Stat.html#expectation-instance_method" title="SpatialStats::Local::Stat#expectation (method)">#expectation</a></span>, <span class='object_link'><a href="Stat.html#mc-instance_method" title="SpatialStats::Local::Stat#mc (method)">#mc</a></span>, <span class='object_link'><a href="Stat.html#mc_bv-instance_method" title="SpatialStats::Local::Stat#mc_bv (method)">#mc_bv</a></span>, <span class='object_link'><a href="Stat.html#quads-instance_method" title="SpatialStats::Local::Stat#quads (method)">#quads</a></span>, <span class='object_link'><a href="Stat.html#summary-instance_method" title="SpatialStats::Local::Stat#summary (method)">#summary</a></span>, <span class='object_link'><a href="Stat.html#variance-instance_method" title="SpatialStats::Local::Stat#variance (method)">#variance</a></span>, <span class='object_link'><a href="Stat.html#z_score-instance_method" title="SpatialStats::Local::Stat#z_score (method)">#z_score</a></span></p>
 <div id="constructor_details" class="method_details_list">
   <h2>Constructor Details</h2>
   
@@ -445,6 +472,66 @@
 </table>
 </div>
     
+      
+      <span id="x=-instance_method"></span>
+      <div class="method_details ">
+  <h3 class="signature " id="x-instance_method">
+  
+    #<strong>x</strong>  &#x21d2; <tt>Array</tt> 
+  
+
+  
+    <span class="aliases">Also known as:
+    <span class="names"><span id='z-instance_method'>z</span></span>
+    </span>
+  
+
+  
+</h3><div class="docstring">
+  <div class="discussion">
+    
+<p>Values of the <code>field</code> queried from the <code>scope</code></p>
+
+
+  </div>
+</div>
+<div class="tags">
+  
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt>Array</tt>)</span>
+      
+      
+      
+    </li>
+  
+</ul>
+
+</div><table class="source_code">
+  <tr>
+    <td>
+      <pre class="lines">
+
+
+64
+65
+66</pre>
+    </td>
+    <td>
+      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/getis_ord.rb', line 64</span>
+
+<span class='kw'>def</span> <span class='id identifier rubyid_x'>x</span>
+  <span class='ivar'>@x</span> <span class='op'>||=</span> <span class='const'><span class='object_link'><a href="../../SpatialStats.html" title="SpatialStats (module)">SpatialStats</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Queries.html" title="SpatialStats::Queries (module)">Queries</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Queries/Variables.html" title="SpatialStats::Queries::Variables (module)">Variables</a></span></span><span class='period'>.</span><span class='id identifier rubyid_query_field'><span class='object_link'><a href="../Queries/Variables.html#query_field-class_method" title="SpatialStats::Queries::Variables.query_field (method)">query_field</a></span></span><span class='lparen'>(</span><span class='ivar'>@scope</span><span class='comma'>,</span> <span class='ivar'>@field</span><span class='rparen'>)</span>
+<span class='kw'>end</span></pre>
+    </td>
+  </tr>
+</table>
+</div>
+    
   </div>
 
 
@@ -453,7 +540,87 @@
 
     
       <div class="method_details first">
-  <h3 class="signature first" id="star?-instance_method">
+  <h3 class="signature first" id="groups-instance_method">
+  
+    #<strong>groups</strong>  &#x21d2; <tt>Array</tt> 
+  
+
+  
+
+  
+</h3><div class="docstring">
+  <div class="discussion">
+    
+<p>Computes the groups each observation belongs to. Potential groups for G are:</p>
+<dl class="rdoc-list label-list"><dt>H
+<dd>
+<p>High</p>
+</dd><dt>L
+<dd>
+<p>Low</p>
+</dd></dl>
+
+<p>Group is high when standardized z is positive, low otherwise.</p>
+
+
+  </div>
+</div>
+<div class="tags">
+  
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt>Array</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>groups for each observation</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+</div><table class="source_code">
+  <tr>
+    <td>
+      <pre class="lines">
+
+
+50
+51
+52
+53
+54
+55
+56
+57
+58</pre>
+    </td>
+    <td>
+      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/getis_ord.rb', line 50</span>
+
+<span class='kw'>def</span> <span class='id identifier rubyid_groups'>groups</span>
+  <span class='id identifier rubyid_z'>z</span><span class='period'>.</span><span class='id identifier rubyid_standardize'>standardize</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid_val'>val</span><span class='op'>|</span>
+    <span class='kw'>if</span> <span class='id identifier rubyid_val'>val</span><span class='period'>.</span><span class='id identifier rubyid_positive?'>positive?</span>
+      <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>H</span><span class='tstring_end'>&#39;</span></span>
+    <span class='kw'>else</span>
+      <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>L</span><span class='tstring_end'>&#39;</span></span>
+    <span class='kw'>end</span>
+  <span class='kw'>end</span>
+<span class='kw'>end</span></pre>
+    </td>
+  </tr>
+</table>
+</div>
+    
+      <div class="method_details ">
+  <h3 class="signature " id="star?-instance_method">
   
     #<strong>star?</strong>  &#x21d2; <tt>Boolean</tt> 
   
@@ -496,16 +663,16 @@
       <pre class="lines">
 
 
-55
-56
-57
-58
-59
-60
-61</pre>
+75
+76
+77
+78
+79
+80
+81</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/getis_ord.rb', line 55</span>
+      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/getis_ord.rb', line 75</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_star?'>star?</span>
   <span class='kw'>if</span> <span class='ivar'>@star</span><span class='period'>.</span><span class='id identifier rubyid_nil?'>nil?</span>
@@ -567,14 +734,14 @@
       <pre class="lines">
 
 
-33
 34
 35
 36
-37</pre>
+37
+38</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/getis_ord.rb', line 33</span>
+      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/getis_ord.rb', line 34</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_stat'>stat</span>
   <span class='id identifier rubyid_x'>x</span><span class='period'>.</span><span class='id identifier rubyid_each_with_index'>each_with_index</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid__x_val'>_x_val</span><span class='comma'>,</span> <span class='id identifier rubyid_idx'>idx</span><span class='op'>|</span>
@@ -586,70 +753,12 @@
 </table>
 </div>
     
-      <div class="method_details ">
-  <h3 class="signature " id="x-instance_method">
-  
-    #<strong>x</strong>  &#x21d2; <tt>Array</tt> 
-  
-
-  
-    <span class="aliases">Also known as:
-    <span class="names"><span id='z-instance_method'>z</span></span>
-    </span>
-  
-
-  
-</h3><div class="docstring">
-  <div class="discussion">
-    
-<p>Values of the <code>field</code> queried from the <code>scope</code></p>
-
-
-  </div>
-</div>
-<div class="tags">
-  
-<p class="tag_title">Returns:</p>
-<ul class="return">
-  
-    <li>
-      
-      
-        <span class='type'>(<tt>Array</tt>)</span>
-      
-      
-      
-    </li>
-  
-</ul>
-
-</div><table class="source_code">
-  <tr>
-    <td>
-      <pre class="lines">
-
-
-44
-45
-46</pre>
-    </td>
-    <td>
-      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/getis_ord.rb', line 44</span>
-
-<span class='kw'>def</span> <span class='id identifier rubyid_x'>x</span>
-  <span class='ivar'>@x</span> <span class='op'>||=</span> <span class='const'><span class='object_link'><a href="../../SpatialStats.html" title="SpatialStats (module)">SpatialStats</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Queries.html" title="SpatialStats::Queries (module)">Queries</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Queries/Variables.html" title="SpatialStats::Queries::Variables (module)">Variables</a></span></span><span class='period'>.</span><span class='id identifier rubyid_query_field'><span class='object_link'><a href="../Queries/Variables.html#query_field-class_method" title="SpatialStats::Queries::Variables.query_field (method)">query_field</a></span></span><span class='lparen'>(</span><span class='ivar'>@scope</span><span class='comma'>,</span> <span class='ivar'>@field</span><span class='rparen'>)</span>
-<span class='kw'>end</span></pre>
-    </td>
-  </tr>
-</table>
-</div>
-    
   </div>
 
 </div>
 
       <div id="footer">
-  Generated on Fri Apr 17 14:11:14 2020 by
+  Generated on Mon Apr 27 11:49:54 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.24 (ruby-2.6.3).
 </div>

--- a/docs/SpatialStats/Local/Moran.html
+++ b/docs/SpatialStats/Local/Moran.html
@@ -116,9 +116,43 @@
 
 
 
+  <h2>Instance Attribute Summary <small><a href="#" class="summary_toggle">collapse</a></small></h2>
+  <ul class="summary">
+    
+      <li class="public ">
+  <span class="summary_signature">
+    
+      <a href="#x-instance_method" title="#x (instance method)">#<strong>x</strong>  &#x21d2; Array </a>
+    
+
+    
+      (also: #z)
+    
+  </span>
+  
+  
+  
+    
+    
+  
+  
+  
+  
+  
+
+  
+    <span class="summary_desc"><div class='inline'>
+<p>Values of the <code>field</code> queried from the <code>scope</code>.</p>
+</div></span>
+  
+</li>
+
+    
+  </ul>
 
 
-  <h2>Instance Attribute Summary</h2>
+
+  
   
   <h3 class="inherited">Attributes inherited from <span class='object_link'><a href="Stat.html" title="SpatialStats::Local::Stat (class)">Stat</a></span></h3>
   <p class="inherited"><span class='object_link'><a href="Stat.html#field-instance_method" title="SpatialStats::Local::Stat#field (method)">#field</a></span>, <span class='object_link'><a href="Stat.html#scope-instance_method" title="SpatialStats::Local::Stat#scope (method)">#scope</a></span>, <span class='object_link'><a href="Stat.html#weights-instance_method" title="SpatialStats::Local::Stat#weights (method)">#weights</a></span></p>
@@ -151,6 +185,30 @@
   
     <span class="summary_desc"><div class='inline'>
 <p>Expected value of I for each observation.</p>
+</div></span>
+  
+</li>
+
+      
+        <li class="public ">
+  <span class="summary_signature">
+    
+      <a href="#groups-instance_method" title="#groups (instance method)">#<strong>groups</strong>  &#x21d2; Array </a>
+    
+
+    
+  </span>
+  
+  
+  
+  
+  
+  
+  
+
+  
+    <span class="summary_desc"><div class='inline'>
+<p>Computes the groups each observation belongs to.</p>
 </div></span>
   
 </li>
@@ -235,32 +293,6 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#x-instance_method" title="#x (instance method)">#<strong>x</strong>  &#x21d2; Array </a>
-    
-
-    
-      (also: #z)
-    
-  </span>
-  
-  
-  
-  
-  
-  
-  
-
-  
-    <span class="summary_desc"><div class='inline'>
-<p>Values of the <code>field</code> queried from the <code>scope</code>.</p>
-</div></span>
-  
-</li>
-
-      
-        <li class="public ">
-  <span class="summary_signature">
-    
       <a href="#z_lag-instance_method" title="#z_lag (instance method)">#<strong>z_lag</strong>  &#x21d2; Array </a>
     
 
@@ -295,7 +327,7 @@
   
   
   <h3 class="inherited">Methods inherited from <span class='object_link'><a href="Stat.html" title="SpatialStats::Local::Stat (class)">Stat</a></span></h3>
-  <p class="inherited"><span class='object_link'><a href="Stat.html#crand-instance_method" title="SpatialStats::Local::Stat#crand (method)">#crand</a></span>, <span class='object_link'><a href="Stat.html#mc-instance_method" title="SpatialStats::Local::Stat#mc (method)">#mc</a></span>, <span class='object_link'><a href="Stat.html#mc_bv-instance_method" title="SpatialStats::Local::Stat#mc_bv (method)">#mc_bv</a></span>, <span class='object_link'><a href="Stat.html#quads-instance_method" title="SpatialStats::Local::Stat#quads (method)">#quads</a></span>, <span class='object_link'><a href="Stat.html#z_score-instance_method" title="SpatialStats::Local::Stat#z_score (method)">#z_score</a></span></p>
+  <p class="inherited"><span class='object_link'><a href="Stat.html#crand-instance_method" title="SpatialStats::Local::Stat#crand (method)">#crand</a></span>, <span class='object_link'><a href="Stat.html#mc-instance_method" title="SpatialStats::Local::Stat#mc (method)">#mc</a></span>, <span class='object_link'><a href="Stat.html#mc_bv-instance_method" title="SpatialStats::Local::Stat#mc_bv (method)">#mc_bv</a></span>, <span class='object_link'><a href="Stat.html#quads-instance_method" title="SpatialStats::Local::Stat#quads (method)">#quads</a></span>, <span class='object_link'><a href="Stat.html#summary-instance_method" title="SpatialStats::Local::Stat#summary (method)">#summary</a></span>, <span class='object_link'><a href="Stat.html#z_score-instance_method" title="SpatialStats::Local::Stat#z_score (method)">#z_score</a></span></p>
 <div id="constructor_details" class="method_details_list">
   <h2>Constructor Details</h2>
   
@@ -389,6 +421,73 @@
   
 </div>
 
+  <div id="instance_attr_details" class="attr_details">
+    <h2>Instance Attribute Details</h2>
+    
+      
+      <span id="x=-instance_method"></span>
+      <div class="method_details first">
+  <h3 class="signature first" id="x-instance_method">
+  
+    #<strong>x</strong>  &#x21d2; <tt>Array</tt> 
+  
+
+  
+    <span class="aliases">Also known as:
+    <span class="names"><span id='z-instance_method'>z</span></span>
+    </span>
+  
+
+  
+</h3><div class="docstring">
+  <div class="discussion">
+    
+<p>Values of the <code>field</code> queried from the <code>scope</code></p>
+
+
+  </div>
+</div>
+<div class="tags">
+  
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt>Array</tt>)</span>
+      
+      
+      
+    </li>
+  
+</ul>
+
+</div><table class="source_code">
+  <tr>
+    <td>
+      <pre class="lines">
+
+
+90
+91
+92
+93</pre>
+    </td>
+    <td>
+      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/moran.rb', line 90</span>
+
+<span class='kw'>def</span> <span class='id identifier rubyid_x'>x</span>
+  <span class='ivar'>@x</span> <span class='op'>||=</span> <span class='const'><span class='object_link'><a href="../../SpatialStats.html" title="SpatialStats (module)">SpatialStats</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Queries.html" title="SpatialStats::Queries (module)">Queries</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Queries/Variables.html" title="SpatialStats::Queries::Variables (module)">Variables</a></span></span><span class='period'>.</span><span class='id identifier rubyid_query_field'><span class='object_link'><a href="../Queries/Variables.html#query_field-class_method" title="SpatialStats::Queries::Variables.query_field (method)">query_field</a></span></span><span class='lparen'>(</span><span class='ivar'>@scope</span><span class='comma'>,</span> <span class='ivar'>@field</span><span class='rparen'>)</span>
+                                         <span class='period'>.</span><span class='id identifier rubyid_standardize'>standardize</span>
+<span class='kw'>end</span></pre>
+    </td>
+  </tr>
+</table>
+</div>
+    
+  </div>
+
 
   <div id="instance_method_details" class="method_details_list">
     <h2>Instance Method Details</h2>
@@ -433,16 +532,16 @@
       <pre class="lines">
 
 
-42
 43
 44
 45
 46
 47
-48</pre>
+48
+49</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/moran.rb', line 42</span>
+      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/moran.rb', line 43</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_expectation'>expectation</span>
   <span class='comment'># since we are using row standardized weights, the expectation
@@ -450,6 +549,80 @@
 </span>  <span class='comment'># a vector where the sum of the weights for each row is the numerator
 </span>  <span class='comment'># in the equation.
 </span>  <span class='op'>-</span><span class='float'>1.0</span> <span class='op'>/</span> <span class='lparen'>(</span><span class='ivar'>@weights</span><span class='period'>.</span><span class='id identifier rubyid_n'>n</span> <span class='op'>-</span> <span class='int'>1</span><span class='rparen'>)</span>
+<span class='kw'>end</span></pre>
+    </td>
+  </tr>
+</table>
+</div>
+    
+      <div class="method_details ">
+  <h3 class="signature " id="groups-instance_method">
+  
+    #<strong>groups</strong>  &#x21d2; <tt>Array</tt> 
+  
+
+  
+
+  
+</h3><div class="docstring">
+  <div class="discussion">
+    
+<p>Computes the groups each observation belongs to. Potential groups for Moran&#39;s I are:</p>
+<dl class="rdoc-list label-list"><dt>HH
+<dd>
+<p>High-High</p>
+</dd><dt>HL
+<dd>
+<p>High-Low</p>
+</dd><dt>LH
+<dd>
+<p>Low-High</p>
+</dd><dt>LL
+<dd>
+<p>Low-Low</p>
+</dd></dl>
+
+<p>This is the same as the <code>#quads</code> method in the <code>Stat</code> class.</p>
+
+
+  </div>
+</div>
+<div class="tags">
+  
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt>Array</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>groups for each observation</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+</div><table class="source_code">
+  <tr>
+    <td>
+      <pre class="lines">
+
+
+82
+83
+84</pre>
+    </td>
+    <td>
+      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/moran.rb', line 82</span>
+
+<span class='kw'>def</span> <span class='id identifier rubyid_groups'>groups</span>
+  <span class='id identifier rubyid_quads'>quads</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -504,14 +677,14 @@
       <pre class="lines">
 
 
-29
 30
 31
 32
-33</pre>
+33
+34</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/moran.rb', line 29</span>
+      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/moran.rb', line 30</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_stat'>stat</span>
   <span class='id identifier rubyid_z'>z</span><span class='period'>.</span><span class='id identifier rubyid_each_with_index'>each_with_index</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid__z_val'>_z_val</span><span class='comma'>,</span> <span class='id identifier rubyid_idx'>idx</span><span class='op'>|</span>
@@ -574,7 +747,6 @@
       <pre class="lines">
 
 
-56
 57
 58
 59
@@ -586,10 +758,11 @@
 65
 66
 67
-68</pre>
+68
+69</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/moran.rb', line 56</span>
+      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/moran.rb', line 57</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_variance'>variance</span>
   <span class='comment'># formula is A - B - (E[I])**2
@@ -603,66 +776,6 @@
     <span class='id identifier rubyid_vars'>vars</span> <span class='op'>&lt;&lt;</span> <span class='lparen'>(</span><span class='id identifier rubyid_a_term'>a_term</span> <span class='op'>-</span> <span class='id identifier rubyid_b_terms'>b_terms</span><span class='lbracket'>[</span><span class='id identifier rubyid_idx'>idx</span><span class='rbracket'>]</span> <span class='op'>-</span> <span class='lparen'>(</span><span class='id identifier rubyid_exp'>exp</span><span class='op'>**</span><span class='int'>2</span><span class='rparen'>)</span><span class='rparen'>)</span>
   <span class='kw'>end</span>
   <span class='id identifier rubyid_vars'>vars</span>
-<span class='kw'>end</span></pre>
-    </td>
-  </tr>
-</table>
-</div>
-    
-      <div class="method_details ">
-  <h3 class="signature " id="x-instance_method">
-  
-    #<strong>x</strong>  &#x21d2; <tt>Array</tt> 
-  
-
-  
-    <span class="aliases">Also known as:
-    <span class="names"><span id='z-instance_method'>z</span></span>
-    </span>
-  
-
-  
-</h3><div class="docstring">
-  <div class="discussion">
-    
-<p>Values of the <code>field</code> queried from the <code>scope</code></p>
-
-
-  </div>
-</div>
-<div class="tags">
-  
-<p class="tag_title">Returns:</p>
-<ul class="return">
-  
-    <li>
-      
-      
-        <span class='type'>(<tt>Array</tt>)</span>
-      
-      
-      
-    </li>
-  
-</ul>
-
-</div><table class="source_code">
-  <tr>
-    <td>
-      <pre class="lines">
-
-
-74
-75
-76
-77</pre>
-    </td>
-    <td>
-      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/moran.rb', line 74</span>
-
-<span class='kw'>def</span> <span class='id identifier rubyid_x'>x</span>
-  <span class='ivar'>@x</span> <span class='op'>||=</span> <span class='const'><span class='object_link'><a href="../../SpatialStats.html" title="SpatialStats (module)">SpatialStats</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Queries.html" title="SpatialStats::Queries (module)">Queries</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Queries/Variables.html" title="SpatialStats::Queries::Variables (module)">Variables</a></span></span><span class='period'>.</span><span class='id identifier rubyid_query_field'><span class='object_link'><a href="../Queries/Variables.html#query_field-class_method" title="SpatialStats::Queries::Variables.query_field (method)">query_field</a></span></span><span class='lparen'>(</span><span class='ivar'>@scope</span><span class='comma'>,</span> <span class='ivar'>@field</span><span class='rparen'>)</span>
-                                         <span class='period'>.</span><span class='id identifier rubyid_standardize'>standardize</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -708,14 +821,14 @@
       <pre class="lines">
 
 
-84
-85
-86
-87
-88</pre>
+100
+101
+102
+103
+104</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/moran.rb', line 84</span>
+      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/moran.rb', line 100</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_z_lag'>z_lag</span>
   <span class='comment'># w is already row_standardized, so we are using
@@ -732,7 +845,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Apr 17 14:11:14 2020 by
+  Generated on Mon Apr 27 11:49:54 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.24 (ruby-2.6.3).
 </div>

--- a/docs/SpatialStats/Local/MultivariateGeary.html
+++ b/docs/SpatialStats/Local/MultivariateGeary.html
@@ -223,6 +223,28 @@
         <li class="public ">
   <span class="summary_signature">
     
+      <a href="#groups-instance_method" title="#groups (instance method)">#<strong>groups</strong>  &#x21d2; Object </a>
+    
+
+    
+  </span>
+  
+  
+  
+  
+  
+  
+  
+
+  
+    <span class="summary_desc"><div class='inline'></div></span>
+  
+</li>
+
+      
+        <li class="public ">
+  <span class="summary_signature">
+    
       <a href="#initialize-instance_method" title="#initialize (instance method)">#<strong>initialize</strong>(scope, fields, weights)  &#x21d2; MultivariateGeary </a>
     
 
@@ -309,7 +331,7 @@
   
   
   <h3 class="inherited">Methods inherited from <span class='object_link'><a href="Stat.html" title="SpatialStats::Local::Stat (class)">Stat</a></span></h3>
-  <p class="inherited"><span class='object_link'><a href="Stat.html#crand-instance_method" title="SpatialStats::Local::Stat#crand (method)">#crand</a></span>, <span class='object_link'><a href="Stat.html#expectation-instance_method" title="SpatialStats::Local::Stat#expectation (method)">#expectation</a></span>, <span class='object_link'><a href="Stat.html#mc_bv-instance_method" title="SpatialStats::Local::Stat#mc_bv (method)">#mc_bv</a></span>, <span class='object_link'><a href="Stat.html#quads-instance_method" title="SpatialStats::Local::Stat#quads (method)">#quads</a></span>, <span class='object_link'><a href="Stat.html#variance-instance_method" title="SpatialStats::Local::Stat#variance (method)">#variance</a></span>, <span class='object_link'><a href="Stat.html#z_score-instance_method" title="SpatialStats::Local::Stat#z_score (method)">#z_score</a></span></p>
+  <p class="inherited"><span class='object_link'><a href="Stat.html#crand-instance_method" title="SpatialStats::Local::Stat#crand (method)">#crand</a></span>, <span class='object_link'><a href="Stat.html#expectation-instance_method" title="SpatialStats::Local::Stat#expectation (method)">#expectation</a></span>, <span class='object_link'><a href="Stat.html#mc_bv-instance_method" title="SpatialStats::Local::Stat#mc_bv (method)">#mc_bv</a></span>, <span class='object_link'><a href="Stat.html#quads-instance_method" title="SpatialStats::Local::Stat#quads (method)">#quads</a></span>, <span class='object_link'><a href="Stat.html#summary-instance_method" title="SpatialStats::Local::Stat#summary (method)">#summary</a></span>, <span class='object_link'><a href="Stat.html#variance-instance_method" title="SpatialStats::Local::Stat#variance (method)">#variance</a></span>, <span class='object_link'><a href="Stat.html#z_score-instance_method" title="SpatialStats::Local::Stat#z_score (method)">#z_score</a></span></p>
 <div id="constructor_details" class="method_details_list">
   <h2>Constructor Details</h2>
   
@@ -547,7 +569,59 @@
 
     
       <div class="method_details first">
-  <h3 class="signature first" id="mc-instance_method">
+  <h3 class="signature first" id="groups-instance_method">
+  
+    #<strong>groups</strong>  &#x21d2; <tt>Object</tt> 
+  
+
+  
+
+  
+</h3><div class="docstring">
+  <div class="discussion">
+    
+
+  </div>
+</div>
+<div class="tags">
+  
+<p class="tag_title">Raises:</p>
+<ul class="raise">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt>NotImplementedError</tt>)</span>
+      
+      
+      
+    </li>
+  
+</ul>
+
+</div><table class="source_code">
+  <tr>
+    <td>
+      <pre class="lines">
+
+
+96
+97
+98</pre>
+    </td>
+    <td>
+      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/multivariate_geary.rb', line 96</span>
+
+<span class='kw'>def</span> <span class='id identifier rubyid_groups'>groups</span>
+  <span class='id identifier rubyid_raise'>raise</span> <span class='const'>NotImplementedError</span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>groups not implemented</span><span class='tstring_end'>&#39;</span></span>
+<span class='kw'>end</span></pre>
+    </td>
+  </tr>
+</table>
+</div>
+    
+      <div class="method_details ">
+  <h3 class="signature " id="mc-instance_method">
   
     #<strong>mc</strong>(permutations = 99, seed = nil)  &#x21d2; <tt>Array</tt> 
   
@@ -674,13 +748,7 @@
 91
 92
 93
-94
-95
-96
-97
-98
-99
-100</pre>
+94</pre>
     </td>
     <td>
       <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/multivariate_geary.rb', line 57</span>
@@ -715,13 +783,7 @@
 
     <span class='comment'># for each field, compute the C value at that index.
 </span>    <span class='id identifier rubyid_stat_i_new'>stat_i_new</span> <span class='op'>=</span> <span class='id identifier rubyid_mc_i'>mc_i</span><span class='lparen'>(</span><span class='id identifier rubyid_wi'>wi</span><span class='comma'>,</span> <span class='id identifier rubyid_shuffles'>shuffles</span><span class='lbracket'>[</span><span class='id identifier rubyid_idx'>idx</span><span class='rbracket'>]</span><span class='comma'>,</span> <span class='id identifier rubyid_idx'>idx</span><span class='rparen'>)</span>
-
-    <span class='id identifier rubyid_rs'>rs</span><span class='lbracket'>[</span><span class='id identifier rubyid_idx'>idx</span><span class='rbracket'>]</span> <span class='op'>=</span> <span class='kw'>if</span> <span class='id identifier rubyid_stat_i_orig'>stat_i_orig</span><span class='period'>.</span><span class='id identifier rubyid_positive?'>positive?</span>
-                <span class='lparen'>(</span><span class='id identifier rubyid_stat_i_new'>stat_i_new</span> <span class='op'>&gt;=</span> <span class='id identifier rubyid_stat_i_orig'>stat_i_orig</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_count'>count</span>
-              <span class='kw'>else</span>
-                <span class='lparen'>(</span><span class='id identifier rubyid_stat_i_new'>stat_i_new</span> <span class='op'>&lt;=</span> <span class='id identifier rubyid_stat_i_orig'>stat_i_orig</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_count'>count</span>
-              <span class='kw'>end</span>
-
+    <span class='id identifier rubyid_rs'>rs</span><span class='lbracket'>[</span><span class='id identifier rubyid_idx'>idx</span><span class='rbracket'>]</span> <span class='op'>=</span> <span class='id identifier rubyid_mc_observation_calc'>mc_observation_calc</span><span class='lparen'>(</span><span class='id identifier rubyid_stat_i_orig'>stat_i_orig</span><span class='comma'>,</span> <span class='id identifier rubyid_stat_i_new'>stat_i_new</span><span class='comma'>,</span> <span class='id identifier rubyid_permutations'>permutations</span><span class='rparen'>)</span>
     <span class='id identifier rubyid_idx'>idx</span> <span class='op'>+=</span> <span class='int'>1</span>
   <span class='kw'>end</span>
 
@@ -817,7 +879,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Apr 17 14:11:15 2020 by
+  Generated on Mon Apr 27 11:49:55 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.24 (ruby-2.6.3).
 </div>

--- a/docs/SpatialStats/Local/Stat.html
+++ b/docs/SpatialStats/Local/Stat.html
@@ -384,6 +384,30 @@
         <li class="public ">
   <span class="summary_signature">
     
+      <a href="#summary-instance_method" title="#summary (instance method)">#<strong>summary</strong>(permutations = 99, seed = nil)  &#x21d2; Array </a>
+    
+
+    
+  </span>
+  
+  
+  
+  
+  
+  
+  
+
+  
+    <span class="summary_desc"><div class='inline'>
+<p>Summary of the statistic.</p>
+</div></span>
+  
+</li>
+
+      
+        <li class="public ">
+  <span class="summary_signature">
+    
       <a href="#variance-instance_method" title="#variance (instance method)">#<strong>variance</strong>  &#x21d2; Object </a>
     
 
@@ -951,7 +975,8 @@
 157
 158
 159
-160</pre>
+160
+161</pre>
     </td>
     <td>
       <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/stat.rb', line 111</span>
@@ -991,15 +1016,16 @@
       <span class='kw'>next</span>
     <span class='kw'>end</span>
     <span class='id identifier rubyid_wi'>wi</span> <span class='op'>=</span> <span class='const'><span class='object_link'><a href="../../Numo.html" title="Numo (module)">Numo</a></span></span><span class='op'>::</span><span class='const'>DFloat</span><span class='period'>.</span><span class='id identifier rubyid_cast'>cast</span><span class='lparen'>(</span><span class='id identifier rubyid_ws'>ws</span><span class='lbracket'>[</span><span class='id identifier rubyid_row_range'>row_range</span><span class='rbracket'>]</span><span class='rparen'>)</span>
-
     <span class='id identifier rubyid_stat_i_new'>stat_i_new</span> <span class='op'>=</span> <span class='id identifier rubyid_mc_i'>mc_i</span><span class='lparen'>(</span><span class='id identifier rubyid_wi'>wi</span><span class='comma'>,</span> <span class='id identifier rubyid_shuffles'>shuffles</span><span class='lbracket'>[</span><span class='id identifier rubyid_idx'>idx</span><span class='rbracket'>]</span><span class='comma'>,</span> <span class='id identifier rubyid_idx'>idx</span><span class='rparen'>)</span>
-    <span class='id identifier rubyid_rs'>rs</span><span class='lbracket'>[</span><span class='id identifier rubyid_idx'>idx</span><span class='rbracket'>]</span> <span class='op'>=</span> <span class='kw'>if</span> <span class='id identifier rubyid_stat_i_orig'>stat_i_orig</span><span class='period'>.</span><span class='id identifier rubyid_positive?'>positive?</span>
-                <span class='lparen'>(</span><span class='id identifier rubyid_stat_i_new'>stat_i_new</span> <span class='op'>&gt;=</span> <span class='id identifier rubyid_stat_i_orig'>stat_i_orig</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_count'>count</span>
-              <span class='kw'>else</span>
-                <span class='lparen'>(</span><span class='id identifier rubyid_stat_i_new'>stat_i_new</span> <span class='op'>&lt;=</span> <span class='id identifier rubyid_stat_i_orig'>stat_i_orig</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_count'>count</span>
-              <span class='kw'>end</span>
 
-    <span class='id identifier rubyid_idx'>idx</span> <span class='op'>+=</span> <span class='int'>1</span>
+    <span class='id identifier rubyid_rs'>rs</span><span class='lbracket'>[</span><span class='id identifier rubyid_idx'>idx</span><span class='rbracket'>]</span> <span class='op'>=</span> <span class='id identifier rubyid_mc_observation_calc'>mc_observation_calc</span><span class='lparen'>(</span><span class='id identifier rubyid_stat_i_orig'>stat_i_orig</span><span class='comma'>,</span> <span class='id identifier rubyid_stat_i_new'>stat_i_new</span><span class='comma'>,</span>
+                                  <span class='id identifier rubyid_permutations'>permutations</span><span class='rparen'>)</span>
+    <span class='comment'># rs[idx] = if stat_i_orig.positive?
+</span>    <span class='comment'>#             (stat_i_new &gt;= stat_i_orig).count
+</span>    <span class='comment'>#           else
+</span>    <span class='comment'>#             (stat_i_new &lt;= stat_i_orig).count
+</span>    <span class='comment'>#           end
+</span>    <span class='id identifier rubyid_idx'>idx</span> <span class='op'>+=</span> <span class='int'>1</span>
   <span class='kw'>end</span>
 
   <span class='id identifier rubyid_rs'>rs</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid_ri'>ri</span><span class='op'>|</span>
@@ -1098,7 +1124,6 @@
       <pre class="lines">
 
 
-174
 175
 176
 177
@@ -1135,10 +1160,13 @@
 208
 209
 210
-211</pre>
+211
+212
+213
+214</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/stat.rb', line 174</span>
+      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/stat.rb', line 175</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_mc_bv'>mc_bv</span><span class='lparen'>(</span><span class='id identifier rubyid_permutations'>permutations</span><span class='comma'>,</span> <span class='id identifier rubyid_seed'>seed</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_rng'>rng</span> <span class='op'>=</span> <span class='id identifier rubyid_gen_rng'>gen_rng</span><span class='lparen'>(</span><span class='id identifier rubyid_seed'>seed</span><span class='rparen'>)</span>
@@ -1165,12 +1193,14 @@
 
     <span class='id identifier rubyid_stat_i_new'>stat_i_new</span> <span class='op'>=</span> <span class='id identifier rubyid_mc_i'>mc_i</span><span class='lparen'>(</span><span class='id identifier rubyid_wi'>wi</span><span class='comma'>,</span> <span class='id identifier rubyid_shuffles'>shuffles</span><span class='lbracket'>[</span><span class='id identifier rubyid_idx'>idx</span><span class='rbracket'>]</span><span class='comma'>,</span> <span class='id identifier rubyid_idx'>idx</span><span class='rparen'>)</span>
 
-    <span class='id identifier rubyid_rs'>rs</span><span class='lbracket'>[</span><span class='id identifier rubyid_idx'>idx</span><span class='rbracket'>]</span> <span class='op'>=</span> <span class='kw'>if</span> <span class='id identifier rubyid_stat_i_orig'>stat_i_orig</span><span class='period'>.</span><span class='id identifier rubyid_positive?'>positive?</span>
-                <span class='lparen'>(</span><span class='id identifier rubyid_stat_i_new'>stat_i_new</span> <span class='op'>&gt;=</span> <span class='id identifier rubyid_stat_i_orig'>stat_i_orig</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_count'>count</span>
-              <span class='kw'>else</span>
-                <span class='lparen'>(</span><span class='id identifier rubyid_stat_i_new'>stat_i_new</span> <span class='op'>&lt;=</span> <span class='id identifier rubyid_stat_i_orig'>stat_i_orig</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_count'>count</span>
-              <span class='kw'>end</span>
-
+    <span class='id identifier rubyid_rs'>rs</span><span class='lbracket'>[</span><span class='id identifier rubyid_idx'>idx</span><span class='rbracket'>]</span> <span class='op'>=</span> <span class='id identifier rubyid_mc_observation_calc'>mc_observation_calc</span><span class='lparen'>(</span><span class='id identifier rubyid_stat_i_orig'>stat_i_orig</span><span class='comma'>,</span> <span class='id identifier rubyid_stat_i_new'>stat_i_new</span><span class='comma'>,</span>
+                                  <span class='id identifier rubyid_permutations'>permutations</span><span class='rparen'>)</span>
+    <span class='comment'># if stat_i_orig.positive?
+</span>    <span class='comment'>#             (stat_i_new &gt;= stat_i_orig).count
+</span>    <span class='comment'>#           else
+</span>    <span class='comment'>#             (stat_i_new &lt;= stat_i_orig).count
+</span>    <span class='comment'>#           end
+</span>
     <span class='id identifier rubyid_idx'>idx</span> <span class='op'>+=</span> <span class='int'>1</span>
   <span class='kw'>end</span>
 
@@ -1244,9 +1274,6 @@
       <pre class="lines">
 
 
-229
-230
-231
 232
 233
 234
@@ -1264,10 +1291,13 @@
 246
 247
 248
-249</pre>
+249
+250
+251
+252</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/stat.rb', line 229</span>
+      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/stat.rb', line 232</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_quads'>quads</span>
   <span class='comment'># https://github.com/pysal/esda/blob/master/esda/moran.py#L925
@@ -1341,6 +1371,108 @@
 
 <span class='kw'>def</span> <span class='id identifier rubyid_stat'>stat</span>
   <span class='id identifier rubyid_raise'>raise</span> <span class='const'>NotImplementedError</span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&#39;</span><span class='tstring_content'>method stat not defined</span><span class='tstring_end'>&#39;</span></span>
+<span class='kw'>end</span></pre>
+    </td>
+  </tr>
+</table>
+</div>
+    
+      <div class="method_details ">
+  <h3 class="signature " id="summary-instance_method">
+  
+    #<strong>summary</strong>(permutations = 99, seed = nil)  &#x21d2; <tt>Array</tt> 
+  
+
+  
+
+  
+</h3><div class="docstring">
+  <div class="discussion">
+    
+<p>Summary of the statistic. Computes <code>stat</code>, <code>mc</code>, and <code>groups</code> then returns the values in a hash array.</p>
+
+
+  </div>
+</div>
+<div class="tags">
+  <p class="tag_title">Parameters:</p>
+<ul class="param">
+  
+    <li>
+      
+        <span class='name'>permutations</span>
+      
+      
+        <span class='type'>(<tt>Integer</tt>)</span>
+      
+      
+        <em class="default">(defaults to: <tt>99</tt>)</em>
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>to run. Last digit should be 9 to produce round numbers.</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>seed</span>
+      
+      
+        <span class='type'>(<tt>Integer</tt>)</span>
+      
+      
+        <em class="default">(defaults to: <tt>nil</tt>)</em>
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>used in random number generator for shuffles.</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt>Array</tt>)</span>
+      
+      
+      
+    </li>
+  
+</ul>
+
+</div><table class="source_code">
+  <tr>
+    <td>
+      <pre class="lines">
+
+
+262
+263
+264
+265
+266
+267
+268</pre>
+    </td>
+    <td>
+      <pre class="code"><span class="info file"># File 'lib/spatial_stats/local/stat.rb', line 262</span>
+
+<span class='kw'>def</span> <span class='id identifier rubyid_summary'>summary</span><span class='lparen'>(</span><span class='id identifier rubyid_permutations'>permutations</span> <span class='op'>=</span> <span class='int'>99</span><span class='comma'>,</span> <span class='id identifier rubyid_seed'>seed</span> <span class='op'>=</span> <span class='kw'>nil</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_p_vals'>p_vals</span> <span class='op'>=</span> <span class='id identifier rubyid_mc'>mc</span><span class='lparen'>(</span><span class='id identifier rubyid_permutations'>permutations</span><span class='comma'>,</span> <span class='id identifier rubyid_seed'>seed</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_data'>data</span> <span class='op'>=</span> <span class='id identifier rubyid_weights'>weights</span><span class='period'>.</span><span class='id identifier rubyid_keys'>keys</span><span class='period'>.</span><span class='id identifier rubyid_zip'>zip</span><span class='lparen'>(</span><span class='id identifier rubyid_stat'>stat</span><span class='comma'>,</span> <span class='id identifier rubyid_p_vals'>p_vals</span><span class='comma'>,</span> <span class='id identifier rubyid_groups'>groups</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid_data'>data</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid_row'>row</span><span class='op'>|</span>
+    <span class='lbrace'>{</span> <span class='label'>key:</span> <span class='id identifier rubyid_row'>row</span><span class='lbracket'>[</span><span class='int'>0</span><span class='rbracket'>]</span><span class='comma'>,</span> <span class='label'>stat:</span> <span class='id identifier rubyid_row'>row</span><span class='lbracket'>[</span><span class='int'>1</span><span class='rbracket'>]</span><span class='comma'>,</span> <span class='label'>p:</span> <span class='id identifier rubyid_row'>row</span><span class='lbracket'>[</span><span class='int'>2</span><span class='rbracket'>]</span><span class='comma'>,</span> <span class='label'>group:</span> <span class='id identifier rubyid_row'>row</span><span class='lbracket'>[</span><span class='int'>3</span><span class='rbracket'>]</span> <span class='rbrace'>}</span>
+  <span class='kw'>end</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -1471,7 +1603,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Apr 17 14:11:14 2020 by
+  Generated on Mon Apr 27 11:49:54 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.24 (ruby-2.6.3).
 </div>

--- a/docs/SpatialStats/Queries.html
+++ b/docs/SpatialStats/Queries.html
@@ -118,7 +118,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Apr 17 14:11:14 2020 by
+  Generated on Mon Apr 27 11:49:54 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.24 (ruby-2.6.3).
 </div>

--- a/docs/SpatialStats/Queries/Variables.html
+++ b/docs/SpatialStats/Queries/Variables.html
@@ -264,7 +264,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Apr 17 14:11:14 2020 by
+  Generated on Mon Apr 27 11:49:54 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.24 (ruby-2.6.3).
 </div>

--- a/docs/SpatialStats/Queries/Weights.html
+++ b/docs/SpatialStats/Queries/Weights.html
@@ -1256,7 +1256,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Apr 17 14:11:14 2020 by
+  Generated on Mon Apr 27 11:49:54 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.24 (ruby-2.6.3).
 </div>

--- a/docs/SpatialStats/Railtie.html
+++ b/docs/SpatialStats/Railtie.html
@@ -114,7 +114,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Apr 17 14:11:14 2020 by
+  Generated on Mon Apr 27 11:49:54 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.24 (ruby-2.6.3).
 </div>

--- a/docs/SpatialStats/Utils.html
+++ b/docs/SpatialStats/Utils.html
@@ -118,7 +118,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Apr 17 14:11:14 2020 by
+  Generated on Mon Apr 27 11:49:54 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.24 (ruby-2.6.3).
 </div>

--- a/docs/SpatialStats/Utils/Lag.html
+++ b/docs/SpatialStats/Utils/Lag.html
@@ -605,7 +605,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Apr 17 14:11:14 2020 by
+  Generated on Mon Apr 27 11:49:54 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.24 (ruby-2.6.3).
 </div>

--- a/docs/SpatialStats/Weights.html
+++ b/docs/SpatialStats/Weights.html
@@ -120,7 +120,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Apr 17 14:11:14 2020 by
+  Generated on Mon Apr 27 11:49:54 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.24 (ruby-2.6.3).
 </div>

--- a/docs/SpatialStats/Weights/CSRMatrix.html
+++ b/docs/SpatialStats/Weights/CSRMatrix.html
@@ -1334,7 +1334,7 @@ VALUE csr_matrix_values(VALUE self)
 </div>
 
       <div id="footer">
-  Generated on Fri Apr 17 14:11:15 2020 by
+  Generated on Mon Apr 27 11:49:55 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.24 (ruby-2.6.3).
 </div>

--- a/docs/SpatialStats/Weights/Contiguous.html
+++ b/docs/SpatialStats/Weights/Contiguous.html
@@ -427,7 +427,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Apr 17 14:11:14 2020 by
+  Generated on Mon Apr 27 11:49:54 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.24 (ruby-2.6.3).
 </div>

--- a/docs/SpatialStats/Weights/Distant.html
+++ b/docs/SpatialStats/Weights/Distant.html
@@ -823,7 +823,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Apr 17 14:11:14 2020 by
+  Generated on Mon Apr 27 11:49:54 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.24 (ruby-2.6.3).
 </div>

--- a/docs/SpatialStats/Weights/WeightsMatrix.html
+++ b/docs/SpatialStats/Weights/WeightsMatrix.html
@@ -846,7 +846,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Apr 17 14:11:15 2020 by
+  Generated on Mon Apr 27 11:49:55 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.24 (ruby-2.6.3).
 </div>

--- a/docs/_index.html
+++ b/docs/_index.html
@@ -375,7 +375,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Apr 17 14:11:14 2020 by
+  Generated on Mon Apr 27 11:49:54 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.24 (ruby-2.6.3).
 </div>

--- a/docs/file.README.html
+++ b/docs/file.README.html
@@ -123,10 +123,10 @@ weights = SpatialStats::Weights::Distant.idw_knn(scope, :geom, 5)
 
 <p>```ruby
 weights = {
-    1 =&gt; [{ j_id: 2, weight: 1 }, { j_id: 4, weight: 1 }],
-    2 =&gt; [{ j_id: 1, weight: 1 }],
-    3 =&gt; [{ j_id: 4, weight: 1 }],
-    4 =&gt; [{ j_id: 1, weight: 1 }, { j_id: 3, weight: 1 }]
+    1 =&gt; [{ id: 2, weight: 1 }, { id: 4, weight: 1 }],
+    2 =&gt; [{ id: 1, weight: 1 }],
+    3 =&gt; [{ id: 4, weight: 1 }],
+    4 =&gt; [{ id: 1, weight: 1 }, { id: 3, weight: 1 }]
 }
 keys = weights.keys
 wm = SpatialStats::Weights::WeightsMatrix.new(keys, weights)
@@ -177,6 +177,26 @@ moran = SpatialStats::Global::Moran.new(scope, :avg_income, weights)
 # =&gt; 0.834
 ```</p>
 
+<h4 id="compute-morans-i-without-querying-data">Compute Moran’s I without Querying Data</h4>
+
+<p>To calculate the statistic by using an array of data and not querying a database field. The order of the data must correspond to the order of <code>weights.keys</code>.</p>
+
+<p>```ruby
+scope = County.all
+weights = SpatialStats::Weights::Contiguous.rook(scope, :geom)</p>
+
+<p>field = nil
+moran = SpatialStats::Global::Moran.new(scope, field, weights)
+# =&gt; &lt;SpatialStats::Global::Moran&gt;</p>
+
+<h1 id="important-to-standardize-the-data">important to standardize the data!</h1>
+<p>data = [1,2,3,4,5,6].standardize
+moran.x = data</p>
+
+<p>moran.stat
+# =&gt; 0.521
+```</p>
+
 <h4 id="compute-morans-i-z-score">Compute Moran’s I Z-Score</h4>
 
 <p>```ruby
@@ -203,6 +223,20 @@ moran = SpatialStats::Global::Moran.new(scope, :avg_income, weights)
 # =&gt; 0.003
 ```</p>
 
+<h4 id="get-summary-of-permutation-test">Get Summary of Permutation Test</h4>
+
+<p>All stat classes have the <code>summary</code> method which takes <code>permutations</code> and <code>seed</code> as its parameters. <code>summary</code> runs <code>stat</code> and <code>mc</code> then combines the results into a hash.</p>
+
+<p>```ruby
+scope = County.all
+weights = SpatialStats::Weights::Contiguous.rook(scope, :geom)
+moran = SpatialStats::Global::Moran.new(scope, :avg_income, weights)
+# =&gt; &lt;SpatialStats::Global::Moran&gt;</p>
+
+<p>moran.summary(999, 123_456)
+# =&gt; 0.834, p: 0.003
+```</p>
+
 <h3 id="local-stats">Local Stats</h3>
 
 <p>Local stats compute a value each observation in the dataset, like how similar its neighbors are to itself. Local stats operate similarly to global stats, except that almost every operation will return an array of length <code>n</code> where <code>n</code> is the number of observations in the dataset.</p>
@@ -222,6 +256,26 @@ moran = SpatialStats::Local::Moran.new(scope, :avg_income, weights)
 
 <p>moran.i
 # =&gt; [0.888, 0.675, 0.2345, -0.987, -0.42, …]
+```</p>
+
+<h4 id="compute-morans-i-without-querying-data-1">Compute Moran’s I without Querying Data</h4>
+
+<p>To calculate the statistic by using an array of data and not querying a database field. The order of the data must correspond to the order of <code>weights.keys</code>.</p>
+
+<p>```ruby
+scope = County.all
+weights = SpatialStats::Weights::Contiguous.rook(scope, :geom)</p>
+
+<p>field = nil
+moran = SpatialStats::Local::Moran.new(scope, field, weights)
+# =&gt; &lt;SpatialStats::Local::Moran&gt;</p>
+
+<h1 id="important-to-standardize-the-data-1">important to standardize the data!</h1>
+<p>data = [1,2,3,4,5,6].standardize
+moran.x = data</p>
+
+<p>moran.stat
+# =&gt; [0.521, 0.123, -0.432, -0.56,. …]
 ```</p>
 
 <h4 id="compute-morans-i-z-scores">Compute Moran’s I Z-Scores</h4>
@@ -250,6 +304,20 @@ moran = SpatialStats::Local::Moran.new(scope, :avg_income, weights)
 
 <p>moran.mc(999, 123_456)
 # =&gt; [0.24, 0.13, 0.53, 0.023, 0.65, …]
+```</p>
+
+<h4 id="get-summary-of-permutation-test-1">Get Summary of Permutation Test</h4>
+
+<p>All stat classes have the <code>summary</code> method which takes <code>permutations</code> and <code>seed</code> as its parameters. <code>summary</code> runs <code>stat</code>, <code>mc</code>, and <code>groups</code> then combines the results into a hash array indexed by <code>weight.keys</code>.</p>
+
+<p>```ruby
+scope = County.all
+weights = SpatialStats::Weights::Contiguous.rook(scope, :geom)
+moran = SpatialStats::Local::Moran.new(scope, :avg_income, weights)
+# =&gt; &lt;SpatialStats::Local::Moran&gt;</p>
+
+<p>moran.summary(999, 123_456)
+# =&gt; [1, stat: 0.521, p: 0.24, group: ‘HH’, …]
 ```</p>
 
 <h2 id="contributing">Contributing</h2>
@@ -304,7 +372,9 @@ rails c</p>
   <li>~~Support non-numeric keys in WeightsMatrix/General refactor~~</li>
   <li>~~Write SparseMatrix C ext~~</li>
   <li>~~Change instances of <code>standardized</code> and <code>windowed</code> to <code>standardize</code> and <code>window</code>, respectively.~~</li>
-  <li>Add <code>#summary</code> method to statistics that will combine stat vals with p-vals, and quads or hot/cold spot info</li>
+  <li>~~Add <code>positive</code> and <code>negative</code> groups for <code>GetisOrd</code> and <code>Geary</code>, similar to how <code>#quads</code> is implemented.~~</li>
+  <li>~~Add <code>#summary</code> method to statistics that will combine stat vals with p-vals, and quads or hot/cold spot info.~~</li>
+  <li>~~Add ability to assign <code>x</code> or <code>z</code> on stat classes so users are not forced to query data to input it into models. Add example to README.~~</li>
 </ul>
 
 <h2 id="future-work">Future Work</h2>
@@ -313,7 +383,7 @@ rails c</p>
 
 <ul>
   <li>~~Refactor stats to inherit an abstract class.~~</li>
-  <li>Change WeightsMatrix class and Stat classes to utilize sparse matrix methods.</li>
+  <li>~~Change WeightsMatrix class and Stat classes to utilize sparse matrix methods.~~</li>
   <li>Split into two separate gems spatial_stats and spatial_stats-activerecord</li>
 </ul>
 
@@ -355,7 +425,7 @@ rails c</p>
 </div></div>
 
       <div id="footer">
-  Generated on Fri Apr 17 14:11:14 2020 by
+  Generated on Mon Apr 27 11:49:54 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.24 (ruby-2.6.3).
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -123,10 +123,10 @@ weights = SpatialStats::Weights::Distant.idw_knn(scope, :geom, 5)
 
 <p>```ruby
 weights = {
-    1 =&gt; [{ j_id: 2, weight: 1 }, { j_id: 4, weight: 1 }],
-    2 =&gt; [{ j_id: 1, weight: 1 }],
-    3 =&gt; [{ j_id: 4, weight: 1 }],
-    4 =&gt; [{ j_id: 1, weight: 1 }, { j_id: 3, weight: 1 }]
+    1 =&gt; [{ id: 2, weight: 1 }, { id: 4, weight: 1 }],
+    2 =&gt; [{ id: 1, weight: 1 }],
+    3 =&gt; [{ id: 4, weight: 1 }],
+    4 =&gt; [{ id: 1, weight: 1 }, { id: 3, weight: 1 }]
 }
 keys = weights.keys
 wm = SpatialStats::Weights::WeightsMatrix.new(keys, weights)
@@ -177,6 +177,26 @@ moran = SpatialStats::Global::Moran.new(scope, :avg_income, weights)
 # =&gt; 0.834
 ```</p>
 
+<h4 id="compute-morans-i-without-querying-data">Compute Moran’s I without Querying Data</h4>
+
+<p>To calculate the statistic by using an array of data and not querying a database field. The order of the data must correspond to the order of <code>weights.keys</code>.</p>
+
+<p>```ruby
+scope = County.all
+weights = SpatialStats::Weights::Contiguous.rook(scope, :geom)</p>
+
+<p>field = nil
+moran = SpatialStats::Global::Moran.new(scope, field, weights)
+# =&gt; &lt;SpatialStats::Global::Moran&gt;</p>
+
+<h1 id="important-to-standardize-the-data">important to standardize the data!</h1>
+<p>data = [1,2,3,4,5,6].standardize
+moran.x = data</p>
+
+<p>moran.stat
+# =&gt; 0.521
+```</p>
+
 <h4 id="compute-morans-i-z-score">Compute Moran’s I Z-Score</h4>
 
 <p>```ruby
@@ -203,6 +223,20 @@ moran = SpatialStats::Global::Moran.new(scope, :avg_income, weights)
 # =&gt; 0.003
 ```</p>
 
+<h4 id="get-summary-of-permutation-test">Get Summary of Permutation Test</h4>
+
+<p>All stat classes have the <code>summary</code> method which takes <code>permutations</code> and <code>seed</code> as its parameters. <code>summary</code> runs <code>stat</code> and <code>mc</code> then combines the results into a hash.</p>
+
+<p>```ruby
+scope = County.all
+weights = SpatialStats::Weights::Contiguous.rook(scope, :geom)
+moran = SpatialStats::Global::Moran.new(scope, :avg_income, weights)
+# =&gt; &lt;SpatialStats::Global::Moran&gt;</p>
+
+<p>moran.summary(999, 123_456)
+# =&gt; 0.834, p: 0.003
+```</p>
+
 <h3 id="local-stats">Local Stats</h3>
 
 <p>Local stats compute a value each observation in the dataset, like how similar its neighbors are to itself. Local stats operate similarly to global stats, except that almost every operation will return an array of length <code>n</code> where <code>n</code> is the number of observations in the dataset.</p>
@@ -222,6 +256,26 @@ moran = SpatialStats::Local::Moran.new(scope, :avg_income, weights)
 
 <p>moran.i
 # =&gt; [0.888, 0.675, 0.2345, -0.987, -0.42, …]
+```</p>
+
+<h4 id="compute-morans-i-without-querying-data-1">Compute Moran’s I without Querying Data</h4>
+
+<p>To calculate the statistic by using an array of data and not querying a database field. The order of the data must correspond to the order of <code>weights.keys</code>.</p>
+
+<p>```ruby
+scope = County.all
+weights = SpatialStats::Weights::Contiguous.rook(scope, :geom)</p>
+
+<p>field = nil
+moran = SpatialStats::Local::Moran.new(scope, field, weights)
+# =&gt; &lt;SpatialStats::Local::Moran&gt;</p>
+
+<h1 id="important-to-standardize-the-data-1">important to standardize the data!</h1>
+<p>data = [1,2,3,4,5,6].standardize
+moran.x = data</p>
+
+<p>moran.stat
+# =&gt; [0.521, 0.123, -0.432, -0.56,. …]
 ```</p>
 
 <h4 id="compute-morans-i-z-scores">Compute Moran’s I Z-Scores</h4>
@@ -250,6 +304,20 @@ moran = SpatialStats::Local::Moran.new(scope, :avg_income, weights)
 
 <p>moran.mc(999, 123_456)
 # =&gt; [0.24, 0.13, 0.53, 0.023, 0.65, …]
+```</p>
+
+<h4 id="get-summary-of-permutation-test-1">Get Summary of Permutation Test</h4>
+
+<p>All stat classes have the <code>summary</code> method which takes <code>permutations</code> and <code>seed</code> as its parameters. <code>summary</code> runs <code>stat</code>, <code>mc</code>, and <code>groups</code> then combines the results into a hash array indexed by <code>weight.keys</code>.</p>
+
+<p>```ruby
+scope = County.all
+weights = SpatialStats::Weights::Contiguous.rook(scope, :geom)
+moran = SpatialStats::Local::Moran.new(scope, :avg_income, weights)
+# =&gt; &lt;SpatialStats::Local::Moran&gt;</p>
+
+<p>moran.summary(999, 123_456)
+# =&gt; [1, stat: 0.521, p: 0.24, group: ‘HH’, …]
 ```</p>
 
 <h2 id="contributing">Contributing</h2>
@@ -304,7 +372,9 @@ rails c</p>
   <li>~~Support non-numeric keys in WeightsMatrix/General refactor~~</li>
   <li>~~Write SparseMatrix C ext~~</li>
   <li>~~Change instances of <code>standardized</code> and <code>windowed</code> to <code>standardize</code> and <code>window</code>, respectively.~~</li>
-  <li>Add <code>#summary</code> method to statistics that will combine stat vals with p-vals, and quads or hot/cold spot info</li>
+  <li>~~Add <code>positive</code> and <code>negative</code> groups for <code>GetisOrd</code> and <code>Geary</code>, similar to how <code>#quads</code> is implemented.~~</li>
+  <li>~~Add <code>#summary</code> method to statistics that will combine stat vals with p-vals, and quads or hot/cold spot info.~~</li>
+  <li>~~Add ability to assign <code>x</code> or <code>z</code> on stat classes so users are not forced to query data to input it into models. Add example to README.~~</li>
 </ul>
 
 <h2 id="future-work">Future Work</h2>
@@ -313,7 +383,7 @@ rails c</p>
 
 <ul>
   <li>~~Refactor stats to inherit an abstract class.~~</li>
-  <li>Change WeightsMatrix class and Stat classes to utilize sparse matrix methods.</li>
+  <li>~~Change WeightsMatrix class and Stat classes to utilize sparse matrix methods.~~</li>
   <li>Split into two separate gems spatial_stats and spatial_stats-activerecord</li>
 </ul>
 
@@ -355,7 +425,7 @@ rails c</p>
 </div></div>
 
       <div id="footer">
-  Generated on Fri Apr 17 14:11:14 2020 by
+  Generated on Mon Apr 27 11:49:54 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.24 (ruby-2.6.3).
 </div>

--- a/docs/method_list.html
+++ b/docs/method_list.html
@@ -174,6 +174,38 @@
 
   <li class="odd ">
     <div class="item">
+      <span class='object_link'><a href="SpatialStats/Local/Geary.html#groups-instance_method" title="SpatialStats::Local::Geary#groups (method)">#groups</a></span>
+      <small>SpatialStats::Local::Geary</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="SpatialStats/Local/Moran.html#groups-instance_method" title="SpatialStats::Local::Moran#groups (method)">#groups</a></span>
+      <small>SpatialStats::Local::Moran</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="SpatialStats/Local/GetisOrd.html#groups-instance_method" title="SpatialStats::Local::GetisOrd#groups (method)">#groups</a></span>
+      <small>SpatialStats::Local::GetisOrd</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="SpatialStats/Local/MultivariateGeary.html#groups-instance_method" title="SpatialStats::Local::MultivariateGeary#groups (method)">#groups</a></span>
+      <small>SpatialStats::Local::MultivariateGeary</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
       <span class='object_link'><a href="SpatialStats/Queries/Weights.html#idw_band-class_method" title="SpatialStats::Queries::Weights.idw_band (method)">idw_band</a></span>
       <small>SpatialStats::Queries::Weights</small>
     </div>
@@ -454,13 +486,21 @@
 
   <li class="even ">
     <div class="item">
+      <span class='object_link'><a href="SpatialStats/Local/BivariateMoran.html#quads-instance_method" title="SpatialStats::Local::BivariateMoran#quads (method)">#quads</a></span>
+      <small>SpatialStats::Local::BivariateMoran</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
       <span class='object_link'><a href="SpatialStats/Weights/Contiguous.html#queen-class_method" title="SpatialStats::Weights::Contiguous.queen (method)">queen</a></span>
       <small>SpatialStats::Weights::Contiguous</small>
     </div>
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Queries/Weights.html#queen_contiguity_neighbors-class_method" title="SpatialStats::Queries::Weights.queen_contiguity_neighbors (method)">queen_contiguity_neighbors</a></span>
       <small>SpatialStats::Queries::Weights</small>
@@ -468,7 +508,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Queries/Variables.html#query_field-class_method" title="SpatialStats::Queries::Variables.query_field (method)">query_field</a></span>
       <small>SpatialStats::Queries::Variables</small>
@@ -476,7 +516,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Weights/Contiguous.html#rook-class_method" title="SpatialStats::Weights::Contiguous.rook (method)">rook</a></span>
       <small>SpatialStats::Weights::Contiguous</small>
@@ -484,7 +524,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Queries/Weights.html#rook_contiguity_neighbors-class_method" title="SpatialStats::Queries::Weights.rook_contiguity_neighbors (method)">rook_contiguity_neighbors</a></span>
       <small>SpatialStats::Queries::Weights</small>
@@ -492,7 +532,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Weights/CSRMatrix.html#row_index-instance_method" title="SpatialStats::Weights::CSRMatrix#row_index (method)">#row_index</a></span>
       <small>SpatialStats::Weights::CSRMatrix</small>
@@ -500,7 +540,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Numo/NArray.html#row_standardize-instance_method" title="Numo::NArray#row_standardize (method)">#row_standardize</a></span>
       <small>Numo::NArray</small>
@@ -508,7 +548,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Enumerable.html#sample_variance-instance_method" title="Enumerable#sample_variance (method)">#sample_variance</a></span>
       <small>Enumerable</small>
@@ -516,7 +556,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Local/Stat.html#scope-instance_method" title="SpatialStats::Local::Stat#scope (method)">#scope</a></span>
       <small>SpatialStats::Local::Stat</small>
@@ -524,7 +564,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Global/Stat.html#scope-instance_method" title="SpatialStats::Global::Stat#scope (method)">#scope</a></span>
       <small>SpatialStats::Global::Stat</small>
@@ -532,7 +572,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Local/BivariateMoran.html#scope-instance_method" title="SpatialStats::Local::BivariateMoran#scope (method)">#scope</a></span>
       <small>SpatialStats::Local::BivariateMoran</small>
@@ -540,7 +580,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Local/MultivariateGeary.html#scope-instance_method" title="SpatialStats::Local::MultivariateGeary#scope (method)">#scope</a></span>
       <small>SpatialStats::Local::MultivariateGeary</small>
@@ -548,7 +588,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Weights/WeightsMatrix.html#sparse-instance_method" title="SpatialStats::Weights::WeightsMatrix#sparse (method)">#sparse</a></span>
       <small>SpatialStats::Weights::WeightsMatrix</small>
@@ -556,7 +596,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Enumerable.html#standardize-instance_method" title="Enumerable#standardize (method)">#standardize</a></span>
       <small>Enumerable</small>
@@ -564,7 +604,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Weights/WeightsMatrix.html#standardize-instance_method" title="SpatialStats::Weights::WeightsMatrix#standardize (method)">#standardize</a></span>
       <small>SpatialStats::Weights::WeightsMatrix</small>
@@ -572,7 +612,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Local/GetisOrd.html#star-instance_method" title="SpatialStats::Local::GetisOrd#star (method)">#star</a></span>
       <small>SpatialStats::Local::GetisOrd</small>
@@ -580,7 +620,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Local/GetisOrd.html#star%3F-instance_method" title="SpatialStats::Local::GetisOrd#star? (method)">#star?</a></span>
       <small>SpatialStats::Local::GetisOrd</small>
@@ -588,7 +628,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Local/Stat.html#stat-instance_method" title="SpatialStats::Local::Stat#stat (method)">#stat</a></span>
       <small>SpatialStats::Local::Stat</small>
@@ -596,7 +636,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Global/Stat.html#stat-instance_method" title="SpatialStats::Global::Stat#stat (method)">#stat</a></span>
       <small>SpatialStats::Global::Stat</small>
@@ -604,7 +644,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Local/Geary.html#stat-instance_method" title="SpatialStats::Local::Geary#stat (method)">#stat</a></span>
       <small>SpatialStats::Local::Geary</small>
@@ -612,7 +652,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Local/Moran.html#stat-instance_method" title="SpatialStats::Local::Moran#stat (method)">#stat</a></span>
       <small>SpatialStats::Local::Moran</small>
@@ -620,7 +660,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Global/Moran.html#stat-instance_method" title="SpatialStats::Global::Moran#stat (method)">#stat</a></span>
       <small>SpatialStats::Global::Moran</small>
@@ -628,7 +668,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Local/GetisOrd.html#stat-instance_method" title="SpatialStats::Local::GetisOrd#stat (method)">#stat</a></span>
       <small>SpatialStats::Local::GetisOrd</small>
@@ -636,7 +676,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Local/BivariateMoran.html#stat-instance_method" title="SpatialStats::Local::BivariateMoran#stat (method)">#stat</a></span>
       <small>SpatialStats::Local::BivariateMoran</small>
@@ -644,7 +684,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Global/BivariateMoran.html#stat-instance_method" title="SpatialStats::Global::BivariateMoran#stat (method)">#stat</a></span>
       <small>SpatialStats::Global::BivariateMoran</small>
@@ -652,7 +692,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Local/MultivariateGeary.html#stat-instance_method" title="SpatialStats::Local::MultivariateGeary#stat (method)">#stat</a></span>
       <small>SpatialStats::Local::MultivariateGeary</small>
@@ -660,7 +700,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Local/BivariateMoran.html#stat_i-instance_method" title="SpatialStats::Local::BivariateMoran#stat_i (method)">#stat_i</a></span>
       <small>SpatialStats::Local::BivariateMoran</small>
@@ -668,7 +708,39 @@
   </li>
   
 
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="SpatialStats/Local/Stat.html#summary-instance_method" title="SpatialStats::Local::Stat#summary (method)">#summary</a></span>
+      <small>SpatialStats::Local::Stat</small>
+    </div>
+  </li>
+  
+
   <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="SpatialStats/Global/Moran.html#summary-instance_method" title="SpatialStats::Global::Moran#summary (method)">#summary</a></span>
+      <small>SpatialStats::Global::Moran</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="SpatialStats/Local/BivariateMoran.html#summary-instance_method" title="SpatialStats::Local::BivariateMoran#summary (method)">#summary</a></span>
+      <small>SpatialStats::Local::BivariateMoran</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="SpatialStats/Global/BivariateMoran.html#summary-instance_method" title="SpatialStats::Global::BivariateMoran#summary (method)">#summary</a></span>
+      <small>SpatialStats::Global::BivariateMoran</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Weights/CSRMatrix.html#values-instance_method" title="SpatialStats::Weights::CSRMatrix#values (method)">#values</a></span>
       <small>SpatialStats::Weights::CSRMatrix</small>
@@ -676,7 +748,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Local/Stat.html#variance-instance_method" title="SpatialStats::Local::Stat#variance (method)">#variance</a></span>
       <small>SpatialStats::Local::Stat</small>
@@ -684,7 +756,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Global/Stat.html#variance-instance_method" title="SpatialStats::Global::Stat#variance (method)">#variance</a></span>
       <small>SpatialStats::Global::Stat</small>
@@ -692,7 +764,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Local/Moran.html#variance-instance_method" title="SpatialStats::Local::Moran#variance (method)">#variance</a></span>
       <small>SpatialStats::Local::Moran</small>
@@ -700,7 +772,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Global/Moran.html#variance-instance_method" title="SpatialStats::Global::Moran#variance (method)">#variance</a></span>
       <small>SpatialStats::Global::Moran</small>
@@ -708,7 +780,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Global/BivariateMoran.html#variance-instance_method" title="SpatialStats::Global::BivariateMoran#variance (method)">#variance</a></span>
       <small>SpatialStats::Global::BivariateMoran</small>
@@ -716,7 +788,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Local/Stat.html#weights-instance_method" title="SpatialStats::Local::Stat#weights (method)">#weights</a></span>
       <small>SpatialStats::Local::Stat</small>
@@ -724,7 +796,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Global/Stat.html#weights-instance_method" title="SpatialStats::Global::Stat#weights (method)">#weights</a></span>
       <small>SpatialStats::Global::Stat</small>
@@ -732,7 +804,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Local/BivariateMoran.html#weights-instance_method" title="SpatialStats::Local::BivariateMoran#weights (method)">#weights</a></span>
       <small>SpatialStats::Local::BivariateMoran</small>
@@ -740,7 +812,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Weights/WeightsMatrix.html#weights-instance_method" title="SpatialStats::Weights::WeightsMatrix#weights (method)">#weights</a></span>
       <small>SpatialStats::Weights::WeightsMatrix</small>
@@ -748,7 +820,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Local/MultivariateGeary.html#weights-instance_method" title="SpatialStats::Local::MultivariateGeary#weights (method)">#weights</a></span>
       <small>SpatialStats::Local::MultivariateGeary</small>
@@ -756,7 +828,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Numo/NArray.html#window-instance_method" title="Numo::NArray#window (method)">#window</a></span>
       <small>Numo::NArray</small>
@@ -764,7 +836,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Weights/WeightsMatrix.html#window-instance_method" title="SpatialStats::Weights::WeightsMatrix#window (method)">#window</a></span>
       <small>SpatialStats::Weights::WeightsMatrix</small>
@@ -772,7 +844,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Utils/Lag.html#window_average-class_method" title="SpatialStats::Utils::Lag.window_average (method)">window_average</a></span>
       <small>SpatialStats::Utils::Lag</small>
@@ -780,7 +852,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Utils/Lag.html#window_sum-class_method" title="SpatialStats::Utils::Lag.window_sum (method)">window_sum</a></span>
       <small>SpatialStats::Utils::Lag</small>
@@ -788,7 +860,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Local/Geary.html#x-instance_method" title="SpatialStats::Local::Geary#x (method)">#x</a></span>
       <small>SpatialStats::Local::Geary</small>
@@ -796,7 +868,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Local/Moran.html#x-instance_method" title="SpatialStats::Local::Moran#x (method)">#x</a></span>
       <small>SpatialStats::Local::Moran</small>
@@ -804,7 +876,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Global/Moran.html#x-instance_method" title="SpatialStats::Global::Moran#x (method)">#x</a></span>
       <small>SpatialStats::Global::Moran</small>
@@ -812,7 +884,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Local/GetisOrd.html#x-instance_method" title="SpatialStats::Local::GetisOrd#x (method)">#x</a></span>
       <small>SpatialStats::Local::GetisOrd</small>
@@ -820,7 +892,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Local/BivariateMoran.html#x-instance_method" title="SpatialStats::Local::BivariateMoran#x (method)">#x</a></span>
       <small>SpatialStats::Local::BivariateMoran</small>
@@ -828,7 +900,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Global/BivariateMoran.html#x-instance_method" title="SpatialStats::Global::BivariateMoran#x (method)">#x</a></span>
       <small>SpatialStats::Global::BivariateMoran</small>
@@ -836,7 +908,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Local/BivariateMoran.html#x_field-instance_method" title="SpatialStats::Local::BivariateMoran#x_field (method)">#x_field</a></span>
       <small>SpatialStats::Local::BivariateMoran</small>
@@ -844,7 +916,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Local/BivariateMoran.html#y-instance_method" title="SpatialStats::Local::BivariateMoran#y (method)">#y</a></span>
       <small>SpatialStats::Local::BivariateMoran</small>
@@ -852,7 +924,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Global/BivariateMoran.html#y-instance_method" title="SpatialStats::Global::BivariateMoran#y (method)">#y</a></span>
       <small>SpatialStats::Global::BivariateMoran</small>
@@ -860,7 +932,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Local/BivariateMoran.html#y_field-instance_method" title="SpatialStats::Local::BivariateMoran#y_field (method)">#y_field</a></span>
       <small>SpatialStats::Local::BivariateMoran</small>
@@ -868,7 +940,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Local/Moran.html#z_lag-instance_method" title="SpatialStats::Local::Moran#z_lag (method)">#z_lag</a></span>
       <small>SpatialStats::Local::Moran</small>
@@ -876,7 +948,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Local/Stat.html#z_score-instance_method" title="SpatialStats::Local::Stat#z_score (method)">#z_score</a></span>
       <small>SpatialStats::Local::Stat</small>
@@ -884,7 +956,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="SpatialStats/Global/Stat.html#z_score-instance_method" title="SpatialStats::Global::Stat#z_score (method)">#z_score</a></span>
       <small>SpatialStats::Global::Stat</small>

--- a/docs/top-level-namespace.html
+++ b/docs/top-level-namespace.html
@@ -100,7 +100,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Apr 17 14:11:14 2020 by
+  Generated on Mon Apr 27 11:49:54 2020 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.24 (ruby-2.6.3).
 </div>

--- a/lib/spatial_stats/global/bivariate_moran.rb
+++ b/lib/spatial_stats/global/bivariate_moran.rb
@@ -89,6 +89,19 @@ module SpatialStats
       end
 
       ##
+      # Summary of the statistic. Computes +stat+ and +mc+ and returns the values
+      # in a hash.
+      #
+      # @param [Integer] permutations to run. Last digit should be 9 to produce round numbers.
+      # @param [Integer] seed used in random number generator for shuffles.
+      #
+      # @return [Hash]
+      def summary(permutations = 99, seed = nil)
+        p_val = mc(permutations, seed)
+        { stat: stat, p: p_val }
+      end
+
+      ##
       # Standardized variables queried from +x_field+.
       #
       # @return [Array]

--- a/lib/spatial_stats/global/moran.rb
+++ b/lib/spatial_stats/global/moran.rb
@@ -92,6 +92,19 @@ module SpatialStats
       end
 
       ##
+      # Summary of the statistic. Computes +stat+ and +mc+ and returns the values
+      # in a hash.
+      #
+      # @param [Integer] permutations to run. Last digit should be 9 to produce round numbers.
+      # @param [Integer] seed used in random number generator for shuffles.
+      #
+      # @return [Hash]
+      def summary(permutations = 99, seed = nil)
+        p_val = mc(permutations, seed)
+        { stat: stat, p: p_val }
+      end
+
+      ##
       # Values of the +field+ queried from the +scope+
       #
       # @return [Array]

--- a/lib/spatial_stats/local/bivariate_moran.rb
+++ b/lib/spatial_stats/local/bivariate_moran.rb
@@ -79,6 +79,15 @@ module SpatialStats
         x[idx] * y_lag_i
       end
 
+      def mc_observation_calc(stat_i_orig, stat_i_new, _permutations)
+        # Since moran can be positive or negative, go by this definition
+        if stat_i_orig.positive?
+          (stat_i_new >= stat_i_orig).count
+        else
+          (stat_i_new <= stat_i_orig).count
+        end
+      end
+
       def y_lag
         @y_lag ||= SpatialStats::Utils::Lag.neighbor_sum(weights, y)
       end

--- a/lib/spatial_stats/local/geary.rb
+++ b/lib/spatial_stats/local/geary.rb
@@ -49,14 +49,25 @@ module SpatialStats
         # just form all of the modified zs and then
         # pass it to a loop of mulvec all implemented in c ext
         zi = z.map { |val| (z[idx] - val)**2 }
-        # zs = Numo::DFloat.cast(z)
-        # zi = ((z[idx] - zs)**2).to_a
         weights.sparse.dot_row(zi, idx)
       end
 
       def mc_i(wi, perms, idx)
         zi = (z[idx] - perms)**2
         (wi * zi).sum(1)
+      end
+
+      def mc_observation_calc(stat_i_orig, stat_i_new, _permutations)
+        # Geary cannot be negative, so we have to use this technique from
+        # GeoDa to determine p values. Note I slightly modified it to be inclusive
+        # on both tails not just the lower tail.
+        # https://github.com/GeoDaCenter/geoda/blob/master/Explore/LocalGearyCoordinator.cpp#L981        mean = stat_i_new.mean
+        mean = stat_i_new.mean
+        if stat_i_orig <= mean
+          (stat_i_new <= stat_i_orig).count
+        else
+          (stat_i_new >= stat_i_orig).count
+        end
       end
     end
   end

--- a/lib/spatial_stats/local/geary.rb
+++ b/lib/spatial_stats/local/geary.rb
@@ -18,6 +18,7 @@ module SpatialStats
       def initialize(scope, field, weights)
         super(scope, field, weights)
       end
+      attr_writer :x
 
       ##
       # Computes Geary's C for every observation in the +scoe+.
@@ -31,6 +32,25 @@ module SpatialStats
         end
       end
       alias c stat
+
+      ##
+      # Computes the groups each observation belongs to.
+      # Potential groups for Geary's C are:
+      # [HH] High-High
+      # [LL] Low-Low
+      # [N] Negative - Group traditionally for HL and LH, but since the difference is squared they are in the same group.
+      #
+      #
+      # @return [Array] groups for each observation
+      def groups
+        quads.map do |quad|
+          if %w[HL LH].include?(quad)
+            'N'
+          else
+            quad
+          end
+        end
+      end
 
       ##
       # Values of the +field+ queried from the +scope+

--- a/lib/spatial_stats/local/getis_ord.rb
+++ b/lib/spatial_stats/local/getis_ord.rb
@@ -71,6 +71,19 @@ module SpatialStats
         x_lag_i / denominators[idx]
       end
 
+      def mc_observation_calc(stat_i_orig, stat_i_new, permutations)
+        # GetisOrd cannot be negative, so we have to use this technique from
+        # ESDA to determine if we should select p or 1-p.
+        # https://github.com/pysal/esda/blob/master/esda/getisord.py#L388
+        num_larger = (stat_i_new >= stat_i_orig).count
+        is_low = (permutations - num_larger) < num_larger
+        if is_low
+          permutations - num_larger
+        else
+          num_larger
+        end
+      end
+
       def calc_weights
         @weights = if star?
                      weights.window.standardize

--- a/lib/spatial_stats/local/getis_ord.rb
+++ b/lib/spatial_stats/local/getis_ord.rb
@@ -25,6 +25,7 @@ module SpatialStats
         calc_weights
       end
       attr_accessor :star
+      attr_writer :x
 
       ##
       # Computes the G or G* statistic for every observation in x.
@@ -36,6 +37,25 @@ module SpatialStats
         end
       end
       alias g stat
+
+      ##
+      # Computes the groups each observation belongs to.
+      # Potential groups for G are:
+      # [H] High
+      # [L] Low
+      #
+      # Group is high when standardized z is positive, low otherwise.
+      #
+      # @return [Array] groups for each observation
+      def groups
+        z.standardize.map do |val|
+          if val.positive?
+            'H'
+          else
+            'L'
+          end
+        end
+      end
 
       ##
       # Values of the +field+ queried from the +scope+

--- a/lib/spatial_stats/local/moran.rb
+++ b/lib/spatial_stats/local/moran.rb
@@ -20,6 +20,7 @@ module SpatialStats
       def initialize(scope, field, weights)
         super(scope, field, weights)
       end
+      attr_writer :x
 
       ##
       # Computes the local indicator of spatial autocorrelation (lisa) for
@@ -65,6 +66,21 @@ module SpatialStats
           vars << (a_term - b_terms[idx] - (exp**2))
         end
         vars
+      end
+
+      ##
+      # Computes the groups each observation belongs to.
+      # Potential groups for Moran's I are:
+      # [HH] High-High
+      # [HL] High-Low
+      # [LH] Low-High
+      # [LL] Low-Low
+      #
+      # This is the same as the +#quads+ method in the +Stat+ class.
+      #
+      # @return [Array] groups for each observation
+      def groups
+        quads
       end
 
       ##

--- a/lib/spatial_stats/local/moran.rb
+++ b/lib/spatial_stats/local/moran.rb
@@ -101,6 +101,15 @@ module SpatialStats
         z[idx] * z_lag_i
       end
 
+      def mc_observation_calc(stat_i_orig, stat_i_new, _permutations)
+        # Since moran can be positive or negative, go by this definition
+        if stat_i_orig.positive?
+          (stat_i_new >= stat_i_orig).count
+        else
+          (stat_i_new <= stat_i_orig).count
+        end
+      end
+
       def si2
         # @si2 ||= z.sample_variance
         # we standardize so sample_variance is 1

--- a/lib/spatial_stats/local/multivariate_geary.rb
+++ b/lib/spatial_stats/local/multivariate_geary.rb
@@ -93,6 +93,10 @@ module SpatialStats
         end
       end
 
+      def groups
+        raise NotImplementedError, 'groups not implemented'
+      end
+
       private
 
       def mc_i(wi, perms, idx)

--- a/lib/spatial_stats/local/multivariate_geary.rb
+++ b/lib/spatial_stats/local/multivariate_geary.rb
@@ -84,13 +84,7 @@ module SpatialStats
 
           # for each field, compute the C value at that index.
           stat_i_new = mc_i(wi, shuffles[idx], idx)
-
-          rs[idx] = if stat_i_orig.positive?
-                      (stat_i_new >= stat_i_orig).count
-                    else
-                      (stat_i_new <= stat_i_orig).count
-                    end
-
+          rs[idx] = mc_observation_calc(stat_i_orig, stat_i_new, permutations)
           idx += 1
         end
 
@@ -114,6 +108,19 @@ module SpatialStats
           cs[mi, true] = (wi * c).sum(1)
         end
         cs.mean(0)
+      end
+
+      def mc_observation_calc(stat_i_orig, stat_i_new, _permutations)
+        # Geary cannot be negative, so we have to use this technique from
+        # GeoDa to determine p values. Note I slightly modified it to be inclusive
+        # on both tails not just the lower tail.
+        # https://github.com/GeoDaCenter/geoda/blob/master/Explore/LocalGearyCoordinator.cpp#L981        mean = stat_i_new.mean
+        mean = stat_i_new.mean
+        if stat_i_orig <= mean
+          (stat_i_new <= stat_i_orig).count
+        else
+          (stat_i_new >= stat_i_orig).count
+        end
       end
 
       def field_data

--- a/lib/spatial_stats/local/stat.rb
+++ b/lib/spatial_stats/local/stat.rb
@@ -251,6 +251,22 @@ module SpatialStats
         end
       end
 
+      ##
+      # Summary of the statistic. Computes +stat+, +mc+, and +groups+ then returns the values
+      # in a hash array.
+      #
+      # @param [Integer] permutations to run. Last digit should be 9 to produce round numbers.
+      # @param [Integer] seed used in random number generator for shuffles.
+      #
+      # @return [Array]
+      def summary(permutations = 99, seed = nil)
+        p_vals = mc(permutations, seed)
+        data = weights.keys.zip(stat, p_vals, groups)
+        data.map do |row|
+          { key: row[0], stat: row[1], p: row[2], group: row[3] }
+        end
+      end
+
       private
 
       def stat_i

--- a/lib/spatial_stats/local/stat.rb
+++ b/lib/spatial_stats/local/stat.rb
@@ -143,14 +143,15 @@ module SpatialStats
             next
           end
           wi = Numo::DFloat.cast(ws[row_range])
-
           stat_i_new = mc_i(wi, shuffles[idx], idx)
-          rs[idx] = if stat_i_orig.positive?
-                      (stat_i_new >= stat_i_orig).count
-                    else
-                      (stat_i_new <= stat_i_orig).count
-                    end
 
+          rs[idx] = mc_observation_calc(stat_i_orig, stat_i_new,
+                                        permutations)
+          # rs[idx] = if stat_i_orig.positive?
+          #             (stat_i_new >= stat_i_orig).count
+          #           else
+          #             (stat_i_new <= stat_i_orig).count
+          #           end
           idx += 1
         end
 
@@ -196,11 +197,13 @@ module SpatialStats
 
           stat_i_new = mc_i(wi, shuffles[idx], idx)
 
-          rs[idx] = if stat_i_orig.positive?
-                      (stat_i_new >= stat_i_orig).count
-                    else
-                      (stat_i_new <= stat_i_orig).count
-                    end
+          rs[idx] = mc_observation_calc(stat_i_orig, stat_i_new,
+                                        permutations)
+          # if stat_i_orig.positive?
+          #             (stat_i_new >= stat_i_orig).count
+          #           else
+          #             (stat_i_new <= stat_i_orig).count
+          #           end
 
           idx += 1
         end
@@ -256,6 +259,10 @@ module SpatialStats
 
       def mc_i
         raise NotImplementedError, 'method mc_i not defined'
+      end
+
+      def mc_observation_calc(_stat_i_orig, _stat_i_new, _permutations)
+        raise NotImplementedError, 'method mc_observation_calc not defined'
       end
 
       def w

--- a/spatial_stats.gemspec
+++ b/spatial_stats.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |spec|
   spec.license     = 'MIT'
   spec.required_ruby_version = Gem::Requirement.new('>= 2.3.0')
 
+  spec.metadata['homepage_uri'] = spec.homepage
+  spec.metadata['source_code_uri'] = spec.homepage
   spec.metadata['documentation_uri'] = 'https://keithdoggett.github.io/spatial_stats/'
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.

--- a/test/global/moran_test.rb
+++ b/test/global/moran_test.rb
@@ -73,4 +73,14 @@ class GlobalMoranTest < ActiveSupport::TestCase
 
     assert_in_delta(expected, p_val, 0.005)
   end
+
+  def test_summary
+    moran = SpatialStats::Global::Moran.new(@poly_scope, :value, @weights)
+    seed = 123_456
+    summary = moran.summary(999, seed)
+    expected = { stat: -1.0, p: 0.01 }
+
+    assert_in_delta(expected[:stat], summary[:stat], 1e-5)
+    assert_in_delta(expected[:p], summary[:p], 1e-5)
+  end
 end

--- a/test/local/bivariate_moran_test.rb
+++ b/test/local/bivariate_moran_test.rb
@@ -52,4 +52,17 @@ class LocalBivariateMoranTest < ActiveSupport::TestCase
       assert_in_delta(v, p_vals[i], 0.0005)
     end
   end
+
+  def test_groups
+    second_values = [1, 1, 1, 1, 1, 1, 0, 0, 0]
+    @poly_scope.each_with_index do |poly, i|
+      poly.second_value = second_values[i]
+      poly.save
+    end
+
+    moran = SpatialStats::Local::BivariateMoran.new(@poly_scope, :value, :second_value, @weights)
+    groups = moran.groups
+    expected = %w[LH HH LH HH LH HH LL HL LL]
+    assert_equal(expected, groups)
+  end
 end

--- a/test/local/geary_test.rb
+++ b/test/local/geary_test.rb
@@ -61,8 +61,31 @@ class LocalGearyTest < ActiveSupport::TestCase
     geary = SpatialStats::Local::Geary.new(@poly_scope, :value, @weights)
     seed = 123_456
     p_vals = geary.mc(999, seed)
+
     expected = [0.216, 0.165, 0.224, 0.184, 0.02, 0.17, 0.224, 0.195, 0.215]
 
+    expected.each_with_index do |v, i|
+      assert_in_delta(v, p_vals[i], 0.0005)
+    end
+  end
+
+  def test_mc_clustered
+    # run this test to make sure the p value calculation still works
+    # for cases where the result is always positive.
+    # If we only go on the >= comparison, it ignores the fact that
+    # something could be very significantly low and end up with PVals
+    # > 95. Have to perform a swap on those and essentially do 1 - p.
+    values = [1, 1, 1, 1, 1, 1, 0, 0, 0]
+    Polygon.all.each_with_index do |poly, i|
+      poly.value = values[i]
+      poly.save
+    end
+
+    geary = SpatialStats::Local::Geary.new(@poly_scope, :value, @weights)
+    seed = 123_456
+    p_vals = geary.mc(999, seed)
+
+    expected = [0.343, 0.187, 0.355, 0.721, 0.477, 0.712, 0.457, 0.109, 0.468]
     expected.each_with_index do |v, i|
       assert_in_delta(v, p_vals[i], 0.0005)
     end

--- a/test/local/geary_test.rb
+++ b/test/local/geary_test.rb
@@ -90,4 +90,11 @@ class LocalGearyTest < ActiveSupport::TestCase
       assert_in_delta(v, p_vals[i], 0.0005)
     end
   end
+
+  def test_groups
+    geary = SpatialStats::Local::Geary.new(@poly_scope, :value, @weights)
+    groups = geary.groups
+    expected = %w[N N N N N N N N N]
+    assert_equal(expected, groups)
+  end
 end

--- a/test/local/getis_ord_test.rb
+++ b/test/local/getis_ord_test.rb
@@ -116,4 +116,11 @@ class LocalGetisOrdTest < ActiveSupport::TestCase
       assert_in_delta(v, p_vals[i], 0.0005)
     end
   end
+
+  def test_groups
+    g = SpatialStats::Local::GetisOrd.new(@poly_scope, :value, @weights)
+    groups = g.groups
+    expected = %w[L H L H L H L H L]
+    assert_equal(expected, groups)
+  end
 end

--- a/test/local/getis_ord_test.rb
+++ b/test/local/getis_ord_test.rb
@@ -87,8 +87,31 @@ class LocalGetisOrdTest < ActiveSupport::TestCase
     g = SpatialStats::Local::GetisOrd.new(@poly_scope, :value, @weights)
     seed = 123_456
     p_vals = g.mc(999, seed)
-    expected = [0.216, 0.165, 0.224, 0.184, 0.02, 0.17, 0.224, 0.195, 0.215]
 
+    expected = [0.216, 0.001, 0.224, 0.001, 0.02, 0.001, 0.224, 0.001, 0.215]
+
+    expected.each_with_index do |v, i|
+      assert_in_delta(v, p_vals[i], 0.0005)
+    end
+  end
+
+  def test_mc_clustered
+    # run this test to make sure the p value calculation still works
+    # for cases where the result is always positive.
+    # If we only go on the >= comparison, it ignores the fact that
+    # something could be very significantly low and end up with PVals
+    # > 95. Have to perform a swap on those and essentially do 1 - p.
+    values = [1, 1, 1, 1, 1, 1, 0, 0, 0]
+    Polygon.all.each_with_index do |poly, i|
+      poly.value = values[i]
+      poly.save
+    end
+
+    g = SpatialStats::Local::GetisOrd.new(@poly_scope, :value, @weights)
+    seed = 123_456
+    p_vals = g.mc(999, seed)
+
+    expected = [0.343, 0.187, 0.355, 0.28, 0.477, 0.289, 0.031, 0.001, 0.039]
     expected.each_with_index do |v, i|
       assert_in_delta(v, p_vals[i], 0.0005)
     end

--- a/test/local/moran_test.rb
+++ b/test/local/moran_test.rb
@@ -127,4 +127,16 @@ class LocalMoranTest < ActiveSupport::TestCase
       assert_in_delta(v, p_vals[i], 0.0005)
     end
   end
+
+  def test_summary
+    moran = SpatialStats::Local::Moran.new(@poly_scope, :value, @weights)
+    seed = 123_456
+    summary = moran.summary(999, seed)
+
+    assert_equal(9, summary.size)
+    assert summary[0].key?(:key)
+    assert summary[0].key?(:stat)
+    assert summary[0].key?(:p)
+    assert summary[0].key?(:group)
+  end
 end

--- a/test/local/multivariate_geary_test.rb
+++ b/test/local/multivariate_geary_test.rb
@@ -32,8 +32,8 @@ class LocalMultivariateGearyTest < ActiveSupport::TestCase
     geary = SpatialStats::Local::MultivariateGeary.new(@poly_scope, %i[value second_value], @weights)
     seed = 123_456
     p_vals = geary.mc(999, seed)
-    expected = [0.519, 0.305, 0.611, 0.829, 0.14, 0.676, 0.544, 0.331, 0.594]
 
+    expected = [0.519, 0.305, 0.611, 0.227, 0.14, 0.342, 0.544, 0.331, 0.594]
     expected.each_with_index do |v, i|
       assert_in_delta(v, p_vals[i], 0.0005)
     end


### PR DESCRIPTION
Fixed `#mc` methods to better reflect `esda` or `GeoDa`. 

Added groupings for all stat types except for `multivariate_geary`.

Created the `summary` method to provide results from `stat` and `mc` in one call.