### PR TITLE
Fix MC Testing Memory Mismanagement

### DIFF
--- a/lib/spatial_stats/weights/weights_matrix.rb
+++ b/lib/spatial_stats/weights/weights_matrix.rb
@@ -59,6 +59,19 @@ module SpatialStats
       end
 
       ##
+      # Compute the cardinalities of each neighbor into an array
+      #
+      # @return [Array]
+      def wc
+        @wc ||= begin
+          row_index = sparse.row_index
+          (0..n - 1).map do |idx|
+            row_index[idx + 1] - row_index[idx]
+          end
+        end
+      end
+
+      ##
       # Row standardized version of the weights matrix.
       # Will return a new version of the weights matrix with standardized
       # weights.

--- a/test/local/moran_test.rb
+++ b/test/local/moran_test.rb
@@ -109,12 +109,10 @@ class LocalMoranTest < ActiveSupport::TestCase
   def test_crand
     # test value will be held in crand
     moran = SpatialStats::Local::Moran.new(@poly_scope, :value, @weights)
-    rands = moran.crand(moran.x, 9, Random.new)
-    neighbor_counts = [2, 3, 2, 3, 4, 3, 2, 3, 2]
-    rands.to_a.each_with_index do |perms, idx|
-      expected = neighbor_counts[idx]
-      assert_equal(expected, perms.shape[1])
-    end
+    rands = moran.crand(9, Random.new)
+
+    assert_equal(9, rands.shape[0])
+    assert_equal(5, rands.shape[1])
   end
 
   def test_mc

--- a/test/local/multivariate_geary_test.rb
+++ b/test/local/multivariate_geary_test.rb
@@ -33,7 +33,7 @@ class LocalMultivariateGearyTest < ActiveSupport::TestCase
     seed = 123_456
     p_vals = geary.mc(999, seed)
 
-    expected = [0.519, 0.305, 0.611, 0.227, 0.14, 0.342, 0.544, 0.331, 0.594]
+    expected = [0.185, 0.313, 0.345, 0.318, 0.21, 0.339, 0.32, 0.452, 0.571]
     expected.each_with_index do |v, i|
       assert_in_delta(v, p_vals[i], 0.0005)
     end

--- a/test/weights/weights_matrix_test.rb
+++ b/test/weights/weights_matrix_test.rb
@@ -49,6 +49,14 @@ class WeightsMatrixTest < ActiveSupport::TestCase
     assert_equal(expected.row_index, result.row_index)
   end
 
+  def test_wc
+    mat = SpatialStats::Weights::WeightsMatrix.new(@weights)
+    expected = [2, 1, 1, 2]
+
+    result = mat.wc
+    assert_equal(expected, result)
+  end
+
   def test_standardize
     mat = SpatialStats::Weights::WeightsMatrix.new(@weights)
     standardized_mat = mat.standardize


### PR DESCRIPTION
Changed the flow of `crand` and `mc` methods in local stat classes so that the memory burden is way less for large datasets.