### PR TITLE
Refactor CSRMatrix Initialization

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spatial_stats (1.0.1)
+    spatial_stats (1.0.2)
       numo-narray (~> 0.9.1)
       rails (~> 6.0.0)
 

--- a/ext/spatial_stats/csr_matrix.h
+++ b/ext/spatial_stats/csr_matrix.h
@@ -4,7 +4,6 @@
 typedef struct csr_matrix
 {
     char init;
-    int m;
     int n;
     int nnz;
     double *values;
@@ -23,9 +22,9 @@ static const rb_data_type_t csr_matrix_type = {
     0,
     RUBY_TYPED_FREE_IMMEDIATELY};
 
-void mat_to_sparse(csr_matrix *csr, VALUE data, VALUE num_rows, VALUE num_cols);
+void mat_to_sparse(csr_matrix *csr, VALUE data, VALUE keys, VALUE num_rows);
 VALUE csr_matrix_alloc(VALUE self);
-VALUE csr_matrix_initialize(VALUE self, VALUE data, VALUE num_rows, VALUE num_cols);
+VALUE csr_matrix_initialize(VALUE self, VALUE data, VALUE num_rows);
 VALUE csr_matrix_values(VALUE self);
 VALUE csr_matrix_col_index(VALUE self);
 VALUE csr_matrix_row_index(VALUE self);

--- a/ext/spatial_stats/spatial_stats.c
+++ b/ext/spatial_stats/spatial_stats.c
@@ -18,7 +18,7 @@ void Init_spatial_stats()
     VALUE csr_matrix_class = rb_define_class_under(weights_mod, "CSRMatrix", rb_cData);
 
     rb_define_alloc_func(csr_matrix_class, csr_matrix_alloc);
-    rb_define_method(csr_matrix_class, "initialize", csr_matrix_initialize, 3);
+    rb_define_method(csr_matrix_class, "initialize", csr_matrix_initialize, 2);
     rb_define_method(csr_matrix_class, "values", csr_matrix_values, 0);
     rb_define_method(csr_matrix_class, "col_index", csr_matrix_col_index, 0);
     rb_define_method(csr_matrix_class, "row_index", csr_matrix_row_index, 0);

--- a/lib/spatial_stats/version.rb
+++ b/lib/spatial_stats/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SpatialStats
-  VERSION = '1.0.1'
+  VERSION = '1.0.2'
 end

--- a/lib/spatial_stats/weights/weights_matrix.rb
+++ b/lib/spatial_stats/weights/weights_matrix.rb
@@ -55,7 +55,7 @@ module SpatialStats
       #
       # @return [CSRMatrix]
       def sparse
-        @sparse ||= CSRMatrix.new(dense.to_a.flatten, n, n)
+        @sparse ||= CSRMatrix.new(weights, n)
       end
 
       ##

--- a/test/weights/csr_matrix_test.rb
+++ b/test/weights/csr_matrix_test.rb
@@ -4,48 +4,66 @@ require 'test_helper'
 
 class CSRMatrixTest < ActiveSupport::TestCase
   def setup
-    @values = [0, 0, 1, 0, 1, 0, 1, 0, 0]
-    @m = 3
+    @weights = {
+      'a' => [{ id: 'c', weight: 1 }],
+      'b' => [{ id: 'b', weight: 1 }],
+      'c' => [{ id: 'a', weight: 1 }]
+    }
     @n = 3
   end
 
   def test_initialize_success
-    csr = SpatialStats::Weights::CSRMatrix.new(@values, @m, @n)
+    csr = SpatialStats::Weights::CSRMatrix.new(@weights, @n)
 
-    assert_equal(3, csr.m)
     assert_equal(3, csr.n)
     assert_equal(3, csr.nnz)
   end
 
   def test_initialize_failure
     assert_raises(ArgumentError) do
-      SpatialStats::Weights::CSRMatrix.new([], @m, @n)
+      SpatialStats::Weights::CSRMatrix.new({}, @n)
     end
   end
 
   def test_values
-    csr = SpatialStats::Weights::CSRMatrix.new(@values, @m, @n)
+    csr = SpatialStats::Weights::CSRMatrix.new(@weights, @n)
     expected = [1, 1, 1]
 
     assert_equal(expected, csr.values)
   end
 
   def test_col_index
-    csr = SpatialStats::Weights::CSRMatrix.new(@values, @m, @n)
+    csr = SpatialStats::Weights::CSRMatrix.new(@weights, @n)
     expected = [2, 1, 0]
 
     assert_equal(expected, csr.col_index)
   end
 
   def test_row_index
-    csr = SpatialStats::Weights::CSRMatrix.new(@values, @m, @n)
+    csr = SpatialStats::Weights::CSRMatrix.new(@weights, @n)
     expected = [0, 1, 2, 3]
 
     assert_equal(expected, csr.row_index)
   end
 
+  def test_initialize_success_neighborless
+    weights = {
+      'a' => [{ id: 'c', weight: 1 }],
+      'b' => [{ id: 'b', weight: 1 }],
+      'c' => [{ id: 'a', weight: 1 }],
+      'd' => []
+    }
+    csr = SpatialStats::Weights::CSRMatrix.new(weights, 4)
+
+    assert_equal(4, csr.n)
+    assert_equal(3, csr.nnz)
+    assert_equal([1, 1, 1], csr.values)
+    assert_equal([2, 1, 0], csr.col_index)
+    assert_equal([0, 1, 2, 3, 3], csr.row_index)
+  end
+
   def test_mulvec_success
-    csr = SpatialStats::Weights::CSRMatrix.new(@values, @m, @n)
+    csr = SpatialStats::Weights::CSRMatrix.new(@weights, @n)
     vec = [1, 2, 3]
     expected = [3, 2, 1]
 
@@ -53,14 +71,14 @@ class CSRMatrixTest < ActiveSupport::TestCase
   end
 
   def test_mulvec_failure
-    csr = SpatialStats::Weights::CSRMatrix.new(@values, @m, @n)
+    csr = SpatialStats::Weights::CSRMatrix.new(@weights, @n)
     vec = [1, 2, 3, 4]
 
     assert_raises(ArgumentError) { csr.mulvec(vec) }
   end
 
   def test_dot_row_success
-    csr = SpatialStats::Weights::CSRMatrix.new(@values, @m, @n)
+    csr = SpatialStats::Weights::CSRMatrix.new(@weights, @n)
     vec = [1, 2, 3]
     expected = 3
 
@@ -69,14 +87,14 @@ class CSRMatrixTest < ActiveSupport::TestCase
   end
 
   def test_dot_row_failure
-    csr = SpatialStats::Weights::CSRMatrix.new(@values, @m, @n)
+    csr = SpatialStats::Weights::CSRMatrix.new(@weights, @n)
     vec = [1, 2, 3, 4]
 
     assert_raises(ArgumentError) { csr.dot_row(vec, 0) }
   end
 
   def test_dot_row_failure_index
-    csr = SpatialStats::Weights::CSRMatrix.new(@values, @m, @n)
+    csr = SpatialStats::Weights::CSRMatrix.new(@weights, @n)
     vec = [1, 2, 3]
     idx = 5 # out of range
 
@@ -84,7 +102,7 @@ class CSRMatrixTest < ActiveSupport::TestCase
   end
 
   def test_coordinates
-    csr = SpatialStats::Weights::CSRMatrix.new(@values, @m, @n)
+    csr = SpatialStats::Weights::CSRMatrix.new(@weights, @n)
     expected = {
       [0, 2] => 1,
       [1, 1] => 1,

--- a/test/weights/weights_matrix_test.rb
+++ b/test/weights/weights_matrix_test.rb
@@ -40,8 +40,7 @@ class WeightsMatrixTest < ActiveSupport::TestCase
   def test_sparse
     mat = SpatialStats::Weights::WeightsMatrix.new(@weights)
 
-    sparse_vals = [0, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0]
-    expected = SpatialStats::Weights::CSRMatrix.new(sparse_vals, 4, 4)
+    expected = SpatialStats::Weights::CSRMatrix.new(@weights, 4)
 
     result = mat.sparse
     assert_equal(expected.values, result.values)


### PR DESCRIPTION
In the case of a large dataset, calling `CSRMatrix.new(dense.to_a.flatten, n, n)` would consume massive amounts of memory due to converting to a dense matrix before making the sparse matrix.

The new version of this uses the DOK weights as the input to reduce the memory burden but makes it less flexible because the matrix is a square by default now.

Ultimately, the loss in flexibility is worth the faster initialization and reduced memory usage.