### PR TITLE
Add Stat Constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `from_observation` class methods to local and global stat classes
+- `==` operator for `WeightsMatrix`
+
 ## [1.0.3] - 2020-05-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -339,6 +339,10 @@ Summaries of milestones for v1.x and v2.0. These lists are subject to change. If
 - Break gem into core `spatial_stats` that will not include queries module and `spatial_stats-activerecord`. This will remove the dependency on rails for the core gem.
 - Create `spatial_stats-import/geojson/shp` gem that will allow importing files and generating a `WeightsMatrix`. Will likely rely on `RGeo` or another spatial lib.
 
+### Other TODOs
+
+- Refactor `MultivariateGeary` so that it can be used without `activerecord` by adding `from_observations` and supporting methods.
+
 ## License
 
 The gem is available as open source under the terms of the [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause).

--- a/lib/spatial_stats/global/bivariate_moran.rb
+++ b/lib/spatial_stats/global/bivariate_moran.rb
@@ -23,6 +23,23 @@ module SpatialStats
       end
 
       ##
+      # A new instance of BivariateMoran, from vector and weights.
+      #
+      # @param [Array] x observations of dataset
+      # @param [WeightsMatrix] weights to define relationships between observations
+      #
+      # @return [BivariateMoran]
+      def self.from_observations(x, y, weights)
+        n = weights.n
+        raise ArgumentError, 'Data size != weights.n' if x.size != n || y.size != n
+
+        instance = new(nil, nil, nil, weights.standardize)
+        instance.x = x
+        instance.y = y
+        instance
+      end
+
+      ##
       # Computes the global spatial correlation of x against spatially lagged
       # y.
       #

--- a/lib/spatial_stats/global/stat.rb
+++ b/lib/spatial_stats/global/stat.rb
@@ -15,6 +15,21 @@ module SpatialStats
       end
       attr_accessor :scope, :field, :weights
 
+      ##
+      # A new instance of Stat, from vector and weights.
+      #
+      # @param [Array] x observations of dataset
+      # @param [WeightsMatrix] weights to define relationships between observations
+      #
+      # @return [Stat]
+      def self.from_observations(x, weights)
+        raise ArgumentError, 'Data size != weights.n' if x.size != weights.n
+
+        instance = new(nil, nil, weights.standardize)
+        instance.x = x
+        instance
+      end
+
       def stat
         raise NotImplementedError, 'method stat not defined'
       end

--- a/lib/spatial_stats/local/bivariate_moran.rb
+++ b/lib/spatial_stats/local/bivariate_moran.rb
@@ -24,6 +24,24 @@ module SpatialStats
       attr_accessor :scope, :x_field, :y_field, :weights
 
       ##
+      # A new instance of BivariateMoran, from vector and weights.
+      #
+      # @param [Array] x observations of dataset
+      # @param [Array] y observations of dataset
+      # @param [WeightsMatrix] weights to define relationships between observations
+      #
+      # @return [BivariateMoran]
+      def self.from_observations(x, y, weights)
+        n = weights.n
+        raise ArgumentError, 'Data size != weights.n' if x.size != n || y.size != n
+
+        instance = new(nil, nil, nil, weights.standardize)
+        instance.x = x
+        instance.y = y
+        instance
+      end
+
+      ##
       # Computes the local indicator of spatial correlation for
       # x against lagged y.
       #

--- a/lib/spatial_stats/local/stat.rb
+++ b/lib/spatial_stats/local/stat.rb
@@ -16,6 +16,21 @@ module SpatialStats
       end
       attr_accessor :scope, :field, :weights
 
+      ##
+      # A new instance of Stat, from vector and weights.
+      #
+      # @param [Array] x observations of dataset
+      # @param [WeightsMatrix] weights to define relationships between observations
+      #
+      # @return [Stat]
+      def self.from_observations(x, weights)
+        raise ArgumentError, 'Data size != weights.n' if x.size != weights.n
+
+        instance = new(nil, nil, weights.standardize)
+        instance.x = x
+        instance
+      end
+
       def stat
         raise NotImplementedError, 'method stat not defined'
       end

--- a/lib/spatial_stats/weights/weights_matrix.rb
+++ b/lib/spatial_stats/weights/weights_matrix.rb
@@ -22,6 +22,16 @@ module SpatialStats
       attr_accessor :keys, :weights, :n
 
       ##
+      # Equality operator
+      #
+      # @param [WeightsMatrix] other WeightsMatrix
+      #
+      # @return [TrueClass, FalseClass] equality result
+      def ==(other)
+        weights == other.weights
+      end
+
+      ##
       # Compute the n x n Numo::Narray of the weights hash.
       #
       # @example

--- a/test/global/bivariate_moran_test.rb
+++ b/test/global/bivariate_moran_test.rb
@@ -18,6 +18,20 @@ class GlobalBivariateMoranTest < ActiveSupport::TestCase
     @weights = SpatialStats::Weights::Contiguous.rook(@poly_scope, :geom)
   end
 
+  def test_from_observations
+    moran = SpatialStats::Global::BivariateMoran.from_observations(@values, @second_values, @weights)
+
+    assert_equal(moran.x, @values.standardize)
+    assert_equal(moran.y, @second_values.standardize)
+    assert_equal(moran.weights, @weights.standardize)
+  end
+
+  def test_from_observations_error
+    assert_raises(ArgumentError) do
+      SpatialStats::Global::BivariateMoran.from_observations([], [], @weights)
+    end
+  end
+
   def test_x
     moran = SpatialStats::Global::BivariateMoran
             .new(@poly_scope, :value, :second_value, @weights)

--- a/test/global/moran_test.rb
+++ b/test/global/moran_test.rb
@@ -17,6 +17,19 @@ class GlobalMoranTest < ActiveSupport::TestCase
     @weights = SpatialStats::Weights::Contiguous.rook(@poly_scope, :geom)
   end
 
+  def test_from_observations
+    moran = SpatialStats::Global::Moran.from_observations(@values, @weights)
+
+    assert_equal(moran.x, @values.standardize)
+    assert_equal(moran.weights, @weights.standardize)
+  end
+
+  def test_from_observations_error
+    assert_raises(ArgumentError) do
+      SpatialStats::Global::Moran.from_observations([], @weights)
+    end
+  end
+
   def test_x
     moran = SpatialStats::Global::Moran.new(@poly_scope, :value, @weights)
     x = moran.x

--- a/test/local/bivariate_moran_test.rb
+++ b/test/local/bivariate_moran_test.rb
@@ -18,6 +18,20 @@ class LocalBivariateMoranTest < ActiveSupport::TestCase
     @weights = SpatialStats::Weights::Contiguous.rook(@poly_scope, :geom)
   end
 
+  def test_from_observations
+    moran = SpatialStats::Local::BivariateMoran.from_observations(@values, @second_values, @weights)
+
+    assert_equal(moran.x, @values.standardize)
+    assert_equal(moran.y, @second_values.standardize)
+    assert_equal(moran.weights, @weights.standardize)
+  end
+
+  def test_from_observations_error
+    assert_raises(ArgumentError) do
+      SpatialStats::Local::BivariateMoran.from_observations([], [], @weights)
+    end
+  end
+
   def test_x
     moran = SpatialStats::Local::BivariateMoran.new(@poly_scope, :value, :second_value, @weights)
     x = moran.x

--- a/test/local/moran_test.rb
+++ b/test/local/moran_test.rb
@@ -16,6 +16,19 @@ class LocalMoranTest < ActiveSupport::TestCase
     @weights = SpatialStats::Weights::Contiguous.rook(@poly_scope, :geom)
   end
 
+  def test_from_observations
+    moran = SpatialStats::Local::Moran.from_observations(@values, @weights)
+
+    assert_equal(moran.x, @values.standardize)
+    assert_equal(moran.weights, @weights.standardize)
+  end
+
+  def test_from_observations_error
+    assert_raises(ArgumentError) do
+      SpatialStats::Local::Moran.from_observations([], @weights)
+    end
+  end
+
   def test_x
     moran = SpatialStats::Local::Moran.new(@poly_scope, :value, @weights)
     x = moran.x

--- a/test/weights/weights_matrix_test.rb
+++ b/test/weights/weights_matrix_test.rb
@@ -21,6 +21,24 @@ class WeightsMatrixTest < ActiveSupport::TestCase
     assert_equal(@weights, mat.weights)
   end
 
+  def test_equality_operator_true
+    mat1 = SpatialStats::Weights::WeightsMatrix.new(@weights)
+    mat2 = SpatialStats::Weights::WeightsMatrix.new(@weights)
+    assert_equal(mat1, mat2)
+  end
+
+  def test_equality_operator_false
+    weights2 = {
+      1 => [{ id: 2, weight: 1 }],
+      2 => [{ id: 1, weight: 1 }],
+      3 => [{ id: 4, weight: 1 }],
+      4 => [{ id: 3, weight: 1 }]
+    }
+    mat1 = SpatialStats::Weights::WeightsMatrix.new(@weights)
+    mat2 = SpatialStats::Weights::WeightsMatrix.new(weights2)
+    assert_not_equal(mat1, mat2)
+  end
+
   def test_dense
     mat = SpatialStats::Weights::WeightsMatrix.new(@weights)
 


### PR DESCRIPTION
## Proposed Changes

Add `from_observations` constructors to local and global stat classes. They take `x` and `weights` as parameters and return a new object. In the case of Bivariate classes, arguments are `x`, `y` and `weights`.

## Additional Info

Raises `ArgumentError` if `x` or `y` are not the same length as the `weights`. 

Created `==` operator for `WeigthtsMatrix`